### PR TITLE
Add support for ignore_https_errors via NovaAct()

### DIFF
--- a/src/nova_act/impl/inputs.py
+++ b/src/nova_act/impl/inputs.py
@@ -188,7 +188,11 @@ def validate_base_parameters(
     screen_width: int,
     screen_height: int,
     chrome_channel: str,
+    ignore_https_errors: bool
 ):
+    if ignore_https_errors not in [True, False]:
+        raise ValueError(f"ignore_https_errors must be True or False")
+
     validate_path(extension_path, "extension_path")
     validate_url(starting_page, "starting_page")
     validate_url(backend_uri, "backend_uri")

--- a/src/nova_act/impl/playwright.py
+++ b/src/nova_act/impl/playwright.py
@@ -72,6 +72,7 @@ class PlaywrightInstanceManager:
         user_agent: str | None,
         logs_directory: str,
         record_video: bool,
+        ignore_https_errors: bool,
     ):
         self._playwright = maybe_playwright
         self._owns_playwright = maybe_playwright is None  # Tracks if we created an instance
@@ -86,6 +87,7 @@ class PlaywrightInstanceManager:
         self.screen_width = screen_width
         self.screen_height = screen_height
         self.user_agent = user_agent
+        self.ignore_https_errors = ignore_https_errors
         self._record_video = bool(record_video and logs_directory)
         self._logs_directory = logs_directory
         self._session_id: str | None = None
@@ -206,6 +208,7 @@ class PlaywrightInstanceManager:
                     ],  # Disable infobar with automated test software message
                     # If you set viewport any user changes to the browser size will skew screenshots
                     "no_viewport": True,
+                    "ignore_https_errors": self.ignore_https_errors,
                     "channel": self._chrome_channel,
                 }
                 if self.user_agent:

--- a/src/nova_act/nova_act.py
+++ b/src/nova_act/nova_act.py
@@ -102,6 +102,7 @@ class NovaAct:
         user_agent: str | None = None,
         logs_directory: str | None = None,
         record_video: bool = False,
+        ignore_https_errors: bool = False,
     ):
         """Initialize a client object.
 
@@ -149,6 +150,8 @@ class NovaAct:
             Output directory for video and agent run output. Will default to a temp dir.
         record_video: bool
             Whether to record video
+        ignore_https_errors: bool
+            Whether to allow website with self-signed certificates
         """
 
         self._backend = Backend.PROD
@@ -196,6 +199,7 @@ class NovaAct:
             screen_height=screen_height,
             logs_directory=self._logs_directory,
             chrome_channel=_chrome_channel,
+            ignore_https_errors=ignore_https_errors
         )
 
         nova_act_api_key = nova_act_api_key or os.environ.get("NOVA_ACT_API_KEY")
@@ -237,6 +241,7 @@ class NovaAct:
             user_agent=user_agent,
             logs_directory=self._logs_directory,
             record_video=record_video,
+            ignore_https_errors=ignore_https_errors
         )
 
         self._dispatcher: ExtensionDispatcher | None = None


### PR DESCRIPTION
Hello,

`NovaAct()` does not support website using self-signed certificates and will throw the following error:
```
playwright._impl._errors.Error: Page.goto: net::ERR_CERT_AUTHORITY_INVALID a
```

This PR allow`ignore_https_errors` (default to `False`) support to `playwright`. Being able to access `NovaAct()` with self-signed certificate is key as development endpoints do not necessarily have a fully trusted SSL certificate

*Description of changes:*

Add `ignore_https_errors` support to NovaAct(). Default to `False` to no break any existing behaviors. Added `ignore_https_errors` to ` validate_base_parameters()`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Tests

I could not find any automated tests/CI, so here are my manual tests instead:

```
nova = NovaAct(starting_page="<SELF_SIGNED_ENDPOINT>")
nova.start()
```

Same as today, this will throw an error: 
`playwright._impl._errors.Error: Page.goto: net::ERR_CERT_AUTHORITY_INVALID at`

---
```
nova = NovaAct(starting_page="<SELF_SIGNED_ENDPOINT>", ignore_https_errors=False)
nova.start()
```

Same as above

---
```
nova = NovaAct(starting_page="<SELF_SIGNED_ENDPOINT>", ignore_https_errors=True)
nova.start()
```
This example allow connection to endpoint using a self-signed certificate

---
```
nova = NovaAct(starting_page="<SELF_SIGNED_ENDPOINT>", ignore_https_errors="Hello")
nova.start()
```

Return an error if ignore_https_errors is not a valid `bool`

```
 validate_base_parameters(
  File "/xx/xx/xx/nova-act/src/nova_act/impl/inputs.py", line 194, in validate_base_parameters
    raise ValueError(f"ignore_https_errors must be True or False")
ValueError: ignore_https_errors must be True or False
```
