### PR TITLE
Include CLI templates in generated wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ optional-dependencies.dev = {file = "requirements-dev.txt"}
 optional-dependencies.cli = {file = "requirements-cli.txt"}
 
 [tool.setuptools.package-data]
-nova_act = ["artifacts/**/*", "artifacts/*"]
+nova_act = ["cli/workflow/services/*/templates/*"]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/src/nova_act/impl/backends/starburst/nova_act_client.py
+++ b/src/nova_act/impl/backends/starburst/nova_act_client.py
@@ -158,9 +158,7 @@ class NovaActClient:
         # Set correct user_agent_extra
         config.user_agent_extra = DEFAULT_USER_AGENT_EXTRA  # type: ignore[attr-defined]
 
-        self._client = boto_session.client(
-            service_name="nova-act", endpoint_url=endpoint_url, config=config
-        )  # type: ignore[call-overload]
+        self._client = boto_session.client(service_name="nova-act", endpoint_url=endpoint_url, config=config)
 
     def _translate_client_error(self, error: ClientError) -> Exception:
         """Translate boto3 ClientError to appropriate SDK error type."""


### PR DESCRIPTION
1. Update pyproject.toml to include the CLI templates in the generated wheel
2. Small nit to remove unused `# type: ignore` on boto3 client