### PR TITLE
Release v3.3.96.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ optional-dependencies.dev = {file = "requirements-dev.txt"}
 optional-dependencies.cli = {file = "requirements-cli.txt"}
 
 [tool.setuptools.package-data]
-nova_act = ["cli/workflow/services/*/templates/*"]
+nova_act = ["cli/workflow/services/*/templates/*", "tools/browser/default/util/*.js"]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -1,2 +1,7 @@
 click
 pyyaml
+filelock>=3.0.0
+psutil>=5.0.0
+markdownify>=1.0.0
+rapidfuzz>=3.0.0
+gherkin-official>=39.0.0

--- a/src/nova_act/__version__.py
+++ b/src/nova_act/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-VERSION = "3.3.35.0"  # pragma: no cover
+VERSION = "3.3.96.0"  # pragma: no cover

--- a/src/nova_act/cli/README.md
+++ b/src/nova_act/cli/README.md
@@ -20,6 +20,117 @@ IMPORTANT: The Nova Act CLI is a convenience utility to quickstart the creation 
 pip install nova-act[cli]
 ```
 
+## Browser Commands
+
+> **🤖 Coding Agents**: Run `act browser --help` for complete command usage, flags, and examples directly in your terminal.
+
+Interactive browser automation commands for quick testing and development. Commands manage browser sessions locally and support custom NovaAct configuration. See `src/nova_act/cli/browser/README.md` for full architecture details.
+
+### Available Commands
+
+| Category | Command | Description |
+|----------|---------|-------------|
+| **Browsing** | `ask` | Ask a read-only question about the current page |
+| | `back` | Go back in browser history |
+| | `click` | Click an element described in natural language |
+| | `console-log` | Capture and display browser console output |
+| | `execute` | Execute browser actions using natural language (primary agent command) |
+| | `fill-form` | Fill out a form using natural language field descriptions |
+| | `forward` | Go forward in browser history |
+| | `goto` | Navigate to a URL (raw Playwright go_to_url) |
+| | `network-log` | Capture and display network requests/responses |
+| | `page` | Get current page info (URL, title) |
+| | `refresh` | Refresh the current page |
+| | `scroll-to` | Scroll to an element or position on the page |
+| | `tab-close` | Close a browser tab |
+| | `tab-list` | List all open browser tabs |
+| | `tab-new` | Open a new browser tab |
+| | `tab-select` | Switch to a specific browser tab |
+| | `type` | Type text into the currently focused element |
+| | `verify` | Visually assert a condition is true on the current page |
+| | `wait-for` | Poll until a condition is met on the current page |
+| **Extraction** | `diff` | Observe page state before and after an action |
+| | `evaluate` | Evaluate a JavaScript expression in the page context |
+| | `extract` | Extract structured data from the current page |
+| | `get-content` | Get page text content in text, HTML, or markdown format |
+| | `pdf` | Save the current page as a PDF file |
+| | `perf` | Collect page performance metrics |
+| | `query` | Query page elements matching a CSS selector |
+| | `screenshot` | Capture a screenshot of the current page |
+| | `snapshot` | Capture accessibility tree snapshot |
+| | `style` | Get computed CSS styles for elements matching a selector |
+| **Session** | `session list` | List all active browser sessions |
+| | `session close` | Close a specific browser session |
+| | `session close-all` | Close all active browser sessions |
+| | `session create` | Create a new browser session |
+| | `session prune` | Remove stale sessions (24h+ inactive by default, or `--all`) |
+| | `session export` | Export session history and artifacts |
+| | `session record-show` | Show session recording |
+| | `session trace-start` | Start CDP tracing |
+| | `session trace-stop` | Stop CDP tracing and save trace file |
+| **Setup** | `doctor` | Run diagnostic checks on the browser CLI environment |
+| | `setup` | Store API key in local config for persistent authentication |
+| | `qa-plan` | Generate QA test plan from Gherkin feature files |
+
+### Basic Usage
+
+```bash
+act browser execute "Go to amazon.com and search for laptops"
+act browser goto https://example.com
+act browser ask "What is the main heading?"
+act browser extract "Get all product prices"
+act browser screenshot --output page.png
+act browser query "a.nav-link" --properties "text,href"
+act browser doctor
+```
+
+### Common Flags
+
+All browsing and extraction commands share these flags:
+
+| Flag | Description |
+|------|-------------|
+| `--session-id` | Session ID (default: `default`) |
+| `--json` | Output results as structured JSON |
+| `--quiet` / `-q` | Suppress SDK output for token efficiency |
+| `--verbose` / `-v` | Show decorated output with full SDK trace |
+| `--headless` / `--headed` | Control browser visibility (default: headless) |
+| `--executable-path` | Path to custom Chromium-based browser executable |
+| `--cdp` | Connect to existing browser via CDP WebSocket endpoint |
+| `--auth-mode` | Authentication mode: `api-key` or `aws` (auto-detected) |
+| `--profile` | AWS profile name for AWS auth |
+| `--nova-arg KEY=VALUE` | Pass additional NovaAct parameters (repeatable) |
+
+### Custom NovaAct Arguments
+
+All browser commands support `--nova-arg key=value` (repeatable) to pass arguments to the NovaAct constructor.
+
+```bash
+act browser execute "test" --nova-arg headless=false --nova-arg screen_width=1920
+```
+
+Supported types: boolean (`true`/`false`/`1`/`0`/`yes`/`no`), integer, float, string. The CLI validates arguments against the NovaAct constructor signature.
+
+### Session Management
+
+Sessions persist across CLI invocations using Chrome DevTools Protocol (CDP):
+
+```bash
+# Default session (reused across commands)
+act browser goto https://example.com
+act browser execute "Click the login button"
+
+# Named sessions for parallel workflows
+act browser goto https://site1.com --session-id session1
+act browser goto https://site2.com --session-id session2
+
+# Session lifecycle management
+act browser session create --session-id work --starting-page https://example.com
+act browser session list
+act browser session close --session-id work
+act browser session prune --all
+```
+
 ## Quick Start
 
 ### Option 1: Named Workflow Management (Recommended)
@@ -131,7 +242,7 @@ act workflow deploy --name my-workflow --source-dir /path/to/code
 
 ## Configuration
 
-Workflows are stored in separate state files per AWS account and region in `~/.act_cli/state/{account_id}/{region}/workflows.json` with file locking for concurrent access protection. User preferences are stored in `~/.act_cli/config.yml`.
+Workflows are stored in separate state files per AWS account and region in `~/.act_cli/state/{account_id}/{region}/workflows.json` with file locking for concurrent access protection. Workflow user preferences are stored in `~/.act_cli/config.yml`. Browser CLI configuration (API key) is stored separately in `~/.act_cli/browser/config.yaml`.
 
 **State File Structure** (`~/.act_cli/state/123456789012/us-east-1/workflows.json`):
 ```json
@@ -500,10 +611,15 @@ arn:aws:nova-act:{region}:{account-id}:workflow-definition/{workflow-name}
 
 ## File Locations
 
-### User Data
+### Workflow Data
 - State files: `~/.act_cli/state/{account_id}/{region}/workflows.json` (per region/account)
-- User config: `~/.act_cli/config.yml`
+- Workflow user config: `~/.act_cli/config.yml`
 - Build artifacts: `~/.act_cli/builds/{workflow-name}/` (persistent)
+
+### Browser Data
+- Browser config: `~/.act_cli/browser/config.yaml` (API key, `0o600` permissions)
+- Session metadata: `~/.act_cli/browser/sessions/` (per-session JSON files)
+- Command logs: `~/.act_cli/browser/session_logs/`
 
 ### Lock Files
 - State locks: `~/.act_cli/state/{account_id}-{region}.lock` (temporary, for concurrent access)

--- a/src/nova_act/cli/browser/README.md
+++ b/src/nova_act/cli/browser/README.md
@@ -1,0 +1,332 @@
+# Browser Commands
+
+> **🤖 Coding Agents**: Run `act browser --help` for complete command usage, flags, and examples directly in your terminal.
+
+Interactive browser automation commands for Nova Act CLI. Execute browser actions using natural language prompts or specific commands.
+
+## Architecture
+
+```
+browser/
+├── __init__.py              # Browser group (registers all commands)
+├── types.py                 # CommandParams dataclass
+├── config_schema.json       # JSON schema for browser config (reference only)
+├── commands/                # CLI command definitions (Click interface)
+│   ├── browsing/            # Browsing commands (19)
+│   │   ├── ask.py           # Read-only page questions
+│   │   ├── back.py          # Browser back navigation
+│   │   ├── click_target.py  # Click an element by description
+│   │   ├── console_log.py   # Capture browser console output
+│   │   ├── execute.py       # Multi-step browser plan delegation
+│   │   ├── fill_form.py     # Form filling via natural language
+│   │   ├── forward.py       # Browser forward navigation
+│   │   ├── goto.py          # Raw Playwright URL navigation
+│   │   ├── network_log.py   # Capture network requests/responses
+│   │   ├── page.py          # Page info (URL, title)
+│   │   ├── refresh.py       # Page refresh
+│   │   ├── scroll_to.py     # Scroll to element or position
+│   │   ├── tab_close.py     # Close a browser tab
+│   │   ├── tab_list.py      # List browser tabs
+│   │   ├── tab_new.py       # Open a new browser tab
+│   │   ├── tab_select.py    # Select/switch browser tab
+│   │   ├── type_text.py     # Type text into focused element
+│   │   ├── verify.py        # Visually assert a condition on the page
+│   │   └── wait_for.py      # Condition polling
+│   ├── extraction/          # Extraction commands (10)
+│   │   ├── diff.py          # Before/after page state observation
+│   │   ├── evaluate.py      # JavaScript expression evaluation
+│   │   ├── extract.py       # Structured data extraction
+│   │   ├── get_content.py   # Page content (text/HTML/markdown)
+│   │   ├── pdf.py           # Save page as PDF
+│   │   ├── perf.py          # Page performance metrics
+│   │   ├── query.py         # CSS selector element queries
+│   │   ├── screenshot.py    # Page screenshot capture
+│   │   ├── snapshot.py      # Accessibility tree snapshot
+│   │   └── style.py         # Computed CSS style inspection
+│   ├── session/             # Session management subcommands (8)
+│   │   ├── close.py         # close + close-all commands
+│   │   ├── create.py        # Session creation with validation
+│   │   ├── export.py        # Export session history and artifacts
+│   │   ├── list.py          # List active sessions
+│   │   ├── prune.py         # Remove stale sessions
+│   │   ├── record_show.py   # Show session recording
+│   │   ├── trace_start.py   # Start CDP tracing
+│   │   └── trace_stop.py    # Stop CDP tracing and save
+│   └── setup/               # Setup commands (4)
+│       ├── cli_doctor.py    # CLIDoctor diagnostic check runner
+│       ├── doctor.py        # Doctor command entry point
+│       ├── qa_plan.py       # Generate QA test plan from Gherkin
+│       └── setup.py         # API key storage command
+├── services/                # Business logic and state management
+│   ├── action_results.py    # Typed result dataclasses
+│   ├── browser_config.py    # DefaultBrowserConfig class
+│   ├── console_capture.py   # Browser console log capture
+│   ├── gherkin_compiler.py  # Gherkin feature file compiler
+│   ├── network_capture.py   # Network request/response capture
+│   ├── performance_collector.py  # Page performance metrics collection
+│   ├── screenshot_annotator.py   # Screenshot annotation with overlays
+│   ├── session_recorder.py  # Session history recording
+│   ├── step_tracking.py     # Command step/trajectory tracking
+│   ├── browser_actions/     # BrowserActions mixin package
+│   │   ├── __init__.py      # BrowserActions class (mixin aggregator)
+│   │   ├── exploration.py   # Ask logic
+│   │   ├── inspection.py    # Query/style/evaluate/diff logic
+│   │   ├── interaction.py   # Execute/fill-form/wait-for logic
+│   │   ├── navigation.py    # Goto logic
+│   │   └── utils.py         # Shared action utilities
+│   ├── intent_resolution/   # Natural language command routing
+│   │   ├── __init__.py      # Re-exports
+│   │   ├── matching.py      # Fuzzy matching logic
+│   │   ├── resolver.py      # Intent resolver
+│   │   └── snapshot.py      # Page state snapshot for context
+│   └── session/             # Session lifecycle management
+│       ├── __init__.py      # Re-exports SessionManager, models
+│       ├── cdp_endpoint_manager.py  # CDP endpoint discovery
+│       ├── chrome_launcher.py       # Chrome process launching
+│       ├── chrome_terminator.py     # Chrome process termination
+│       ├── closer.py               # Session close logic
+│       ├── connector.py            # CDP connection management
+│       ├── locking.py              # File-based session locking
+│       ├── manager.py              # SessionManager (main entry point)
+│       ├── models.py               # SessionInfo, BrowserOptions, SessionState
+│       ├── persistence.py          # Session metadata file I/O
+│       └── pruner.py               # Stale session cleanup
+└── utils/                   # Shared utilities
+    ├── auth.py              # Authentication resolution
+    ├── browser_config_cli.py # Headless mode resolution + screenshot config
+    ├── decorators.py        # Shared Click decorators + CommandParams packing
+    ├── disk_usage.py        # Disk usage warnings for session data
+    ├── error_handlers.py    # Common error handling decorator
+    ├── file_output.py       # File output formatting
+    ├── log_capture.py       # Command log capture (TeeWriter)
+    ├── nova_args.py         # --nova-arg parsing and validation
+    ├── orientation.py       # Auto-orientation context for commands
+    ├── parsing.py           # CLI argument parsing utilities
+    ├── session.py           # Session preparation (command_session() CM)
+    ├── timeout.py           # Timeout handling
+    └── validation_utils.py  # Input validation helpers
+```
+
+The browser CLI also depends on shared modules in `nova_act.cli.core/`:
+- `config.py` — CLI path management and browser config I/O
+- `output.py` — Formatted terminal output helpers
+- `json_output.py` — Structured JSON output mode
+- `cli_stdout.py` — Stdout capture utilities
+- `locking.py` — File-based locking
+- `nova_args.py` — NovaAct argument parsing and validation
+- `exceptions.py` — CLI exception types
+- `constants.py` — Shared constants (paths, defaults)
+- `process.py` — Process utilities
+
+## Supported Browsers / OS
+
+- **Browsers**: Chromium-based only — Chrome, Chromium, Edge
+- **Operating Systems**:
+  - macOS ✅
+  - Linux ✅
+  - Windows ❌ (not supported)
+
+## Design Principles
+
+- **Commands**: Thin CLI wiring layer using Click decorators. Delegates to services via `command_session()` context manager and `BrowserActions` methods. Uses `CommandParams` (from `types.py`) to bundle common parameters.
+- **Services**: Business logic independent of CLI framework. `BrowserActions` is a mixin-based class decomposed into 5 files by domain (exploration, inspection, interaction, navigation, utils). `SessionManager` orchestrates the session lifecycle through dedicated submodules.
+- **Utils**: Shared utilities across commands. `command_session()` is the unified context manager that handles session preparation, NovaAct instantiation, and cleanup. `decorators.py` provides composite Click decorators that pack parameters into `CommandParams`.
+- **Separation**: Commands never directly manage browser state or NovaAct instances.
+
+## Import Patterns
+
+```python
+# In command files
+from nova_act.cli.browser.services import SessionManager
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.utils.session import command_session
+from nova_act.cli.browser.types import CommandParams
+
+# commands/__init__.py re-exports from subpackages:
+from nova_act.cli.browser.commands.browsing import ask, execute, ...
+from nova_act.cli.browser.commands.extraction import diff, evaluate, extract, ...
+from nova_act.cli.browser.commands.session import session
+from nova_act.cli.browser.commands.setup import doctor, setup
+```
+
+## Commands
+
+### Browsing (19 commands)
+
+| Command | Description |
+|---------|-------------|
+| `ask` | Ask a read-only question about the current page (observation only) |
+| `back` | Go back in browser history |
+| `click` | Click an element described in natural language |
+| `console-log` | Capture and display browser console output |
+| `execute` | Delegate a multi-step browser plan using natural language (primary agent command) |
+| `fill-form` | Fill out a form using natural language field descriptions |
+| `forward` | Go forward in browser history |
+| `goto` | Navigate to a URL via raw Playwright `go_to_url` |
+| `network-log` | Capture and display network requests/responses |
+| `page` | Get current page info (URL, title) |
+| `refresh` | Refresh the current page |
+| `scroll-to` | Scroll to an element or position on the page |
+| `tab-close` | Close a browser tab |
+| `tab-list` | List all open browser tabs |
+| `tab-new` | Open a new browser tab |
+| `tab-select` | Switch to a specific browser tab |
+| `type` | Type text into the currently focused element |
+| `verify` | Visually assert a condition is true on the current page |
+| `wait-for` | Poll until a condition is met (each poll = 1 inference call) |
+
+### Extraction (10 commands)
+
+| Command | Description |
+|---------|-------------|
+| `diff` | Observe page state before and after an action (3 inference calls) |
+| `evaluate` | Evaluate a JavaScript expression in the page context |
+| `extract` | Extract structured data with optional `--schema` JSON schema |
+| `get-content` | Get page content in text, HTML, or markdown format |
+| `pdf` | Save the current page as a PDF file |
+| `perf` | Collect page performance metrics (timing, resources, vitals) |
+| `query` | Query elements matching a CSS selector with `--properties` filter |
+| `screenshot` | Capture screenshot with `--full-page`, `--format`, `--quality` options |
+| `snapshot` | Capture accessibility tree snapshot of the page |
+| `style` | Get computed CSS styles for elements matching a selector |
+
+Extraction commands that return structured data (`extract`, `get-content`, `query`, `style`, `evaluate`, `screenshot`) support `--output`/`-o` for writing results to a file.
+
+### Session (8 subcommands under `act browser session`)
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all active browser sessions |
+| `close` | Close a specific session (`--session-id`, `--force`) |
+| `close-all` | Close all active browser sessions |
+| `create` | Create a new session with `--starting-page` and `--headed` options |
+| `prune` | Remove stale sessions (24h+ inactive by default, `--all` for all non-active) |
+| `export` | Export session history, screenshots, and command logs |
+| `record-show` | Show session recording |
+| `trace-start` | Start CDP tracing for performance analysis |
+| `trace-stop` | Stop CDP tracing and save trace file |
+
+### Setup (4 commands)
+
+| Command | Description |
+|---------|-------------|
+| `doctor` | Run diagnostic checks (Chrome, API key, sessions, Playwright) |
+| `setup` | Store API key in `~/.act_cli/browser/config.yaml` for persistent auth |
+| `qa-plan` | Generate a QA test plan from Gherkin feature files |
+
+## Common Flags
+
+All browsing and extraction commands share these flags via composite decorators:
+
+| Flag | Description |
+|------|-------------|
+| `--session-id` | Session ID (default: `default`) |
+| `--nova-arg KEY=VALUE` | Pass additional NovaAct parameters (repeatable) |
+| `--headless` | Launch browser in headless mode (no visible UI) |
+| `--headed` | Launch browser in headed mode (visible UI) |
+| `--executable-path` | Path to custom Chromium-based browser executable |
+| `--profile-path` | Path to browser profile directory |
+| `--use-default-chrome` | Use default Chrome with extensions (quits running Chrome, rsyncs profile; macOS only) |
+| `--user-data-dir` | Working directory for Chrome profile (auto-created if omitted with `--use-default-chrome`) |
+| `--launch-arg` | Additional Chrome launch argument (repeatable) |
+| `--cdp` | Connect to existing browser via CDP WebSocket endpoint |
+| `--ignore-https-errors/--no-ignore-https-errors` | Ignore HTTPS certificate errors (enabled by default) |
+| `--auth-mode` | Authentication mode: `api-key` or `aws` (auto-detected if omitted) |
+| `--profile` | AWS profile name for AWS auth |
+| `--region` | AWS region for AWS auth |
+| `--workflow-name` | Workflow definition name for AWS auth |
+| `--json` | Output results as structured JSON |
+| `--quiet` / `-q` | Suppress SDK output for token efficiency |
+| `--verbose` / `-v` | Show decorated output with full SDK trace |
+| `--no-screenshot-on-failure` | Disable automatic screenshot capture on act() failure |
+
+Setup commands (`doctor`, `setup`) support only `--json` and `--verbose`.
+
+## Session Management
+
+Sessions persist across CLI invocations using Chrome DevTools Protocol (CDP). The `session/` service package handles the full lifecycle:
+
+- **manager.py**: `SessionManager` — main entry point for create/connect/close/list
+- **persistence.py**: File-based session metadata storage (`~/.act_cli/browser/sessions/`)
+- **chrome_launcher.py**: Chrome process launching with profile and config support
+- **chrome_terminator.py**: Chrome process termination (graceful SIGTERM → force SIGKILL)
+- **connector.py**: CDP WebSocket connection management
+- **cdp_endpoint_manager.py**: CDP endpoint validation and polling
+- **closer.py**: Graceful session teardown with Chrome process termination
+- **locking.py**: File-based session locking to prevent concurrent access
+- **pruner.py**: Stale session cleanup with configurable TTL
+- **models.py**: `SessionInfo`, `BrowserOptions`, `SessionState` dataclasses
+
+## Configuration
+
+### Headless Mode Resolution
+
+Headless mode follows this precedence (highest to lowest):
+
+1. CLI flags (`--headless` or `--headed`)
+2. `NOVA_ACT_HEADLESS` environment variable (`true`/`false`/`1`/`0`/`yes`/`no`)
+3. Default: headless (for agent workflows)
+
+### Browser CLI Config
+
+API key and browser preferences are stored in `~/.act_cli/browser/config.yaml` (YAML format, `0o600` permissions). Managed via `act browser setup`.
+
+### Workflow CLI Config
+
+Workflow user preferences are stored separately in `~/.act_cli/config.yml`.
+
+## Security Considerations
+
+> **⚠️ This tool controls a real browser with real credentials.** Any page you navigate to, any form you fill, and any JavaScript you execute operates in a real browser session with full access to your authenticated state (cookies, local storage, session tokens). Treat browser CLI sessions with the same caution as manual browsing.
+
+### API Key Handling
+
+- **Never commit API keys to source control.** Use `act browser setup` to store your key in `~/.act_cli/browser/config.yaml` (created with `0o600` permissions — owner-read/write only).
+- The API key is held in the `NOVA_ACT_API_KEY` environment variable during process execution. This is standard for SDK credential passing but means the key is accessible to any code running in the same process.
+- Prefer environment variables (`export NOVA_ACT_API_KEY=...`) over CLI arguments to avoid shell history exposure.
+
+### Session Data Sensitivity
+
+- Session metadata is stored in `~/.act_cli/browser/sessions/` with `0o700` directory permissions.
+- Session files contain CDP endpoints, browser PIDs, and connection metadata. They do **not** contain API keys.
+- Use `act browser session prune` to clean up stale session data.
+
+### Network and Console Log Contents
+
+- **Network capture** stores full HTTP request/response headers in memory during a session, including `Authorization`, `Cookie`, and `Set-Cookie` headers. These headers are **not** displayed in `network-log` output (only URL, method, status, resource type, duration, and size are shown), but they remain in process memory until the session ends.
+- **Console capture** stores page console output (`console.log`, `console.error`, etc.) in memory. Web pages may log sensitive data (tokens, user info, API responses) to the console.
+- Neither network nor console data is persisted to disk unless you explicitly use `export`.
+
+### Evaluate Command
+
+- `evaluate` executes **arbitrary JavaScript** in the page context. This has the same power as the browser DevTools console — it can read cookies, access local storage, modify the DOM, and make network requests as the authenticated user.
+- Never run untrusted JavaScript expressions. Validate any dynamically-generated JS before execution.
+
+### Export Command
+
+- `export` bundles session history, screenshots, and command logs into a single file. This file may contain sensitive page content, URLs visited, and visual captures of authenticated pages.
+- Export files are created with default umask permissions. Store exports in secure locations and delete them when no longer needed.
+
+### Chrome Launch Arguments (`--launch-arg`)
+
+- `--launch-arg` passes arguments directly to the Chrome process without validation. This is a power-user feature.
+- **Dangerous flags to avoid** unless you understand the implications:
+  - `--disable-web-security` — disables same-origin policy
+  - `--no-sandbox` — disables Chrome's sandbox (auto-added only in CI/Docker environments)
+  - `--disable-site-isolation-trials` — weakens process isolation
+  - `--allow-running-insecure-content` — allows HTTP content on HTTPS pages
+
+### HTTPS Error Handling
+
+- `--ignore-https-errors` is **enabled by default** for convenience in development and automation workflows. This means the browser will accept invalid, expired, and self-signed TLS certificates.
+- For security-sensitive workflows, use `--no-ignore-https-errors` to enforce strict certificate validation.
+
+### CDP Connection Security
+
+- Local Chrome sessions use `ws://localhost` for CDP connections, which is safe for local use.
+- If connecting to a remote CDP endpoint via `--cdp`, prefer `wss://` (encrypted WebSocket) over `ws://` to protect the connection from eavesdropping.
+
+### Log Files
+
+- Command log files (when `--verbose` logging is enabled) may contain SDK trace output including page content and URLs visited. These files are created with default system umask permissions.
+- Review and delete log files after debugging sessions.

--- a/src/nova_act/cli/browser/__init__.py
+++ b/src/nova_act/cli/browser/__init__.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser command group for Nova Act CLI."""
+
+import click
+
+from nova_act.cli.browser.commands import (
+    ask,
+    back,
+    click_target,
+    console_log,
+    diff,
+    doctor,
+    evaluate,
+    execute,
+    extract,
+    fill_form,
+    forward,
+    get_content,
+    goto,
+    network_log,
+    page,
+    pdf,
+    perf,
+    qa_plan,
+    query,
+    refresh,
+    screenshot,
+    scroll_to,
+    snapshot,
+    style,
+    tab_close,
+    tab_list,
+    tab_new,
+    tab_select,
+    type_text,
+    verify,
+    wait_for,
+)
+from nova_act.cli.browser.commands.session import session
+from nova_act.cli.browser.commands.setup.setup import setup
+from nova_act.cli.group import StyledGroup
+
+
+@click.group(cls=StyledGroup)
+def browser() -> None:
+    """Interactive browser automation commands.
+
+    Execute browser actions using natural language prompts or specific commands.
+
+    Examples:
+        act browser execute "Click the login button"
+        act browser goto https://example.com
+        act browser screenshot --output output.png
+    """
+    pass
+
+
+# Register commands in desired order
+browser.add_command(ask)
+browser.add_command(back)
+browser.add_command(console_log)
+browser.add_command(diff)
+browser.add_command(click_target)
+browser.add_command(doctor)
+browser.add_command(evaluate)
+browser.add_command(execute)
+browser.add_command(forward)
+browser.add_command(goto)
+browser.add_command(fill_form)
+browser.add_command(network_log)
+browser.add_command(page)
+browser.add_command(pdf)
+browser.add_command(perf)
+browser.add_command(qa_plan)
+browser.add_command(screenshot)
+browser.add_command(scroll_to)
+browser.add_command(setup)
+browser.add_command(snapshot)
+browser.add_command(extract)
+browser.add_command(get_content)
+browser.add_command(query)
+browser.add_command(refresh)
+browser.add_command(session)
+browser.add_command(style)
+browser.add_command(tab_close)
+browser.add_command(tab_list)
+browser.add_command(tab_new)
+browser.add_command(tab_select)
+browser.add_command(type_text)
+browser.add_command(verify)
+browser.add_command(wait_for)

--- a/src/nova_act/cli/browser/commands/__init__.py
+++ b/src/nova_act/cli/browser/commands/__init__.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser commands module.
+
+Note: ``session`` and ``setup`` Click commands are NOT re-exported here.
+Re-exporting them shadows the subpackage names (``commands.session``,
+``commands.setup``), which breaks ``unittest.mock.patch()`` on Python 3.10
+because ``mock._dot_lookup`` resolves the Click object instead of the module.
+Import these commands directly from their submodules instead.
+"""
+
+__all__ = [
+    "ask",
+    "back",
+    "click_target",
+    "console_log",
+    "diff",
+    "doctor",
+    "evaluate",
+    "execute",
+    "extract",
+    "fill_form",
+    "forward",
+    "get_content",
+    "goto",
+    "network_log",
+    "page",
+    "pdf",
+    "perf",
+    "qa_plan",
+    "query",
+    "refresh",
+    "screenshot",
+    "scroll_to",
+    "snapshot",
+    "style",
+    "tab_close",
+    "tab_list",
+    "tab_new",
+    "tab_select",
+    "type_text",
+    "verify",
+    "wait_for",
+]
+
+from nova_act.cli.browser.commands.browsing.ask import ask
+from nova_act.cli.browser.commands.browsing.back import back
+from nova_act.cli.browser.commands.browsing.click_target import click_target
+from nova_act.cli.browser.commands.browsing.console_log import console_log
+from nova_act.cli.browser.commands.browsing.execute import execute
+from nova_act.cli.browser.commands.browsing.fill_form import fill_form
+from nova_act.cli.browser.commands.browsing.forward import forward
+from nova_act.cli.browser.commands.browsing.goto import goto
+from nova_act.cli.browser.commands.browsing.network_log import network_log
+from nova_act.cli.browser.commands.browsing.page import page
+from nova_act.cli.browser.commands.browsing.refresh import refresh
+from nova_act.cli.browser.commands.browsing.scroll_to import scroll_to
+from nova_act.cli.browser.commands.browsing.tab_close import tab_close
+from nova_act.cli.browser.commands.browsing.tab_list import tab_list
+from nova_act.cli.browser.commands.browsing.tab_new import tab_new
+from nova_act.cli.browser.commands.browsing.tab_select import tab_select
+from nova_act.cli.browser.commands.browsing.type_text import type_text
+from nova_act.cli.browser.commands.browsing.verify import verify
+from nova_act.cli.browser.commands.browsing.wait_for import wait_for
+from nova_act.cli.browser.commands.extraction.diff import diff
+from nova_act.cli.browser.commands.extraction.evaluate import evaluate
+from nova_act.cli.browser.commands.extraction.extract import extract
+from nova_act.cli.browser.commands.extraction.get_content import get_content
+from nova_act.cli.browser.commands.extraction.pdf import pdf
+from nova_act.cli.browser.commands.extraction.perf import perf
+from nova_act.cli.browser.commands.extraction.query import query
+from nova_act.cli.browser.commands.extraction.screenshot import screenshot
+from nova_act.cli.browser.commands.extraction.snapshot import snapshot
+from nova_act.cli.browser.commands.extraction.style import style
+from nova_act.cli.browser.commands.setup.doctor import doctor
+from nova_act.cli.browser.commands.setup.qa_plan import qa_plan

--- a/src/nova_act/cli/browser/commands/browsing/__init__.py
+++ b/src/nova_act/cli/browser/commands/browsing/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browsing commands for browser interaction.
+
+This package groups browsing-related commands:
+- goto: navigate to URL
+- execute: run prompts
+- ask: ask questions about page
+- fill_form: form filling
+- wait_for: wait for conditions
+
+Note: Commands are NOT re-exported here to avoid shadowing submodule names,
+which breaks unittest.mock.patch() on Python 3.10. Import commands directly
+from their submodules (e.g., from nova_act.cli.browser.commands.browsing.execute import execute).
+"""

--- a/src/nova_act/cli/browser/commands/browsing/ask.py
+++ b/src/nova_act/cli/browser/commands/browsing/ask.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ask command — read-only question about the current page."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@click.argument("question")
+@click.option("--schema", help="JSON Schema (Draft 7) for structured answer (overrides default)")
+@click.option("--focus", help="Focus answer on a specific page area")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for the act_get() call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def ask(
+    question: str,
+    schema: str | None,
+    focus: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Ask a read-only question about the current page.
+
+    Does not interact with the page — observation only.
+
+    Examples:
+        act browser ask "What is the main heading?" --session-id my-session
+        act browser ask "What is the price?" --focus "the checkout summary" --json
+        act browser ask "What links are on this page?" --schema '{"type":"object","properties":{"links":{"type":"array","items":{"type":"string"}}}}'  # noqa: E501
+        act browser ask "What is on this page?" --starting-page https://example.com
+    """
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "ask", prep.manager, prep.session_info, params, log_args={"question": question, "focus": focus}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.ask(question, schema=schema, focus=focus, timeout=timeout, **prep.method_args)
+
+    echo_success("Question answered", details={k: v for k, v in asdict(result).items() if k != "question"})

--- a/src/nova_act/cli/browser/commands/browsing/back.py
+++ b/src/nova_act/cli/browser/commands/browsing/back.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Back command — navigate browser history backward."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def back(params: CommandParams) -> None:
+    """Go back one page in browser history (Playwright go_back).
+
+    Examples:
+        act browser back
+        act browser back --session-id my-session
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("back", prep.manager, prep.session_info, params, log_args={}) as nova_act:
+        page = get_active_page(nova_act, prep.session_info)
+        page.go_back(wait_until="commit")
+        url = page.url
+        title = page.title()
+
+    echo_success("Navigated back", details={"URL": url, "Title": title})

--- a/src/nova_act/cli/browser/commands/browsing/click_target.py
+++ b/src/nova_act/cli/browser/commands/browsing/click_target.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Click command — click a target element on the current page."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("click")
+@click.argument("target")
+@click.option("--focus", help="Narrow AI attention to a specific page area")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def click_target(
+    target: str,
+    focus: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Click a target element on the current page.
+
+    TARGET can be a natural language description, CSS selector, or snapshot ref (e.g. e12).
+
+    Examples:
+        act browser click "Submit button"
+        act browser click "#submit-btn"
+        act browser click "e12"
+        act browser click "Login" --focus "the navigation bar"
+        act browser click "Add to cart" --starting-page https://example.com/shop
+    """
+    validate_starting_page(starting_page)
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "click", prep.manager, prep.session_info, params, log_args={"target": target, "focus": focus}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.click(target, focus=focus, timeout=timeout, **prep.method_args)
+
+        echo_success("Clicked target", details=asdict(result))

--- a/src/nova_act/cli/browser/commands/browsing/console_log.py
+++ b/src/nova_act/cli/browser/commands/browsing/console_log.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Console-log command — display captured browser console messages."""
+
+from __future__ import annotations
+
+import json as _json
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.console_capture import (
+    ConsoleCaptureService,
+    ConsoleEntry,
+)
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import echo_success, get_cli_stdout
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+# Module-level registry: session_id -> ConsoleCaptureService
+_capture_registry: dict[str, ConsoleCaptureService] = {}
+
+
+def get_or_create_capture(session_id: str) -> ConsoleCaptureService:
+    """Get existing capture service or create a new one for the session."""
+    if session_id not in _capture_registry:
+        _capture_registry[session_id] = ConsoleCaptureService()
+    return _capture_registry[session_id]
+
+
+def _entry_to_dict(entry: ConsoleEntry) -> dict[str, object]:
+    result: dict[str, object] = {
+        "level": entry.level,
+        "text": entry.text,
+        "timestamp": entry.timestamp,
+    }
+    if entry.source_url:
+        result["source_url"] = entry.source_url
+    if entry.line_number is not None:
+        result["line_number"] = entry.line_number
+    if entry.column_number is not None:
+        result["column_number"] = entry.column_number
+    if entry.args:
+        result["args"] = entry.args
+    return result
+
+
+def _format_entry_line(entry: ConsoleEntry) -> str:
+    level = entry.level.upper()
+    source = ""
+    if entry.source_url:
+        url = entry.source_url.rsplit("/", 1)[-1] if "/" in entry.source_url else entry.source_url
+        if entry.line_number is not None:
+            source = f"{url}:{entry.line_number}"
+        else:
+            source = url
+    text = entry.text[:80] + "..." if len(entry.text) > 80 else entry.text
+    return f"{level:<10} {text:<80} {source}"
+
+
+@click.command("console-log")
+@click.option("--level", default=None, help="Filter by level (log, warning, error, info, debug, pageerror)")
+@click.option("--filter", "text_filter", default=None, help="Glob pattern to filter message text")
+@click.option("--limit", default=50, type=int, help="Max entries to display (default: 50)")
+@click.option("--clear", is_flag=True, help="Clear captured entries")
+@click.option("--errors-only", is_flag=True, help="Show only error and pageerror entries")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def console_log(
+    level: str | None,
+    text_filter: str | None,
+    limit: int,
+    clear: bool,
+    errors_only: bool,
+    params: CommandParams,
+) -> None:
+    """Display captured browser console messages and page errors.
+
+    Captures console.log/warn/error/info/debug and uncaught page errors
+    using Playwright event listeners. On first call, starts monitoring.
+    Subsequent calls display accumulated entries.
+
+    Examples:
+        act browser console-log
+        act browser console-log --level error
+        act browser console-log --errors-only
+        act browser console-log --filter "*TypeError*"
+        act browser console-log --clear
+        act browser console-log --json
+    """
+    prep = prepare_session(params, None)
+    capture = get_or_create_capture(params.session_id)
+
+    with command_session("console-log", prep.manager, prep.session_info, params) as nova_act:
+        if not capture.is_attached:
+            capture.attach(get_active_page(nova_act, prep.session_info))
+            if clear:
+                capture.clear()
+                echo_success("Console capture started and cleared")
+                return
+            echo_success(
+                "Console monitoring started",
+                details={"message": "Run commands, then re-run console-log to see messages"},
+            )
+            return
+
+        if clear:
+            capture.clear()
+            echo_success("Console log cleared")
+            return
+
+        entries = capture.get_entries(level=level, text_filter=text_filter, errors_only=errors_only, limit=limit)
+        _emit_entries(entries, capture.entry_count, params.session_id)
+
+
+def _emit_entries(entries: list[ConsoleEntry], total: int, session_id: str) -> None:
+    """Output entries in JSON or text format."""
+    out = get_cli_stdout()
+    if is_json_mode():
+        payload = {
+            "status": "success",
+            "data": {
+                "total_captured": total,
+                "showing": len(entries),
+                "entries": [_entry_to_dict(e) for e in entries],
+            },
+        }
+        click.echo(_json.dumps(payload), file=out)
+    else:
+        click.echo("status: success", file=out)
+        click.echo(f"total_captured: {total}", file=out)
+        click.echo(f"showing: {len(entries)}", file=out)
+        if entries:
+            click.echo(f"{'LEVEL':<10} {'MESSAGE':<80} SOURCE", file=out)
+            for entry in entries:
+                click.echo(_format_entry_line(entry), file=out)
+        else:
+            click.echo("No matching entries", file=out)

--- a/src/nova_act/cli/browser/commands/browsing/execute.py
+++ b/src/nova_act/cli/browser/commands/browsing/execute.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Execute command — primary delegation interface for multi-step browser plans."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import (
+    validate_prompt,
+    validate_starting_page,
+)
+from nova_act.cli.core.output import echo_success
+
+
+@click.command()
+@click.argument("prompt")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for the act() call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def execute(
+    prompt: str,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Delegate a multi-step browser plan to the visual intelligence agent.
+
+    This is the primary delegation command. Pass a full natural language plan
+    describing everything the agent should do in the browser — multiple steps,
+    navigation, interactions, and assertions can all be included in a single call.
+    The agent executes the entire plan sequentially.
+
+    Default to execute with a detailed multi-step plan. Only drop to individual
+    commands (click, goto, snapshot) for error recovery or surgical precision.
+
+    Examples:
+        act browser execute "Go to amazon.com, search for laptops, click the first result, and extract the price"
+        act browser execute "Navigate to github.com/login, enter username and password, click Sign in"
+        act browser execute "Open the settings page, enable dark mode, and confirm the theme changed"
+        act browser execute "Search for 'wireless headphones' on bestbuy.com and add the top-rated result to the cart"
+        act browser execute "Fill out the contact form with name and email, then submit it" --session-id my-session
+        act browser execute "Click the first result" --headed
+        act browser execute "test action" --nova-arg max_steps=5
+    """
+    validate_prompt(prompt)
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "execute", prep.manager, prep.session_info, params, log_args={"prompt": prompt, "timeout": timeout}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.execute(prompt, timeout=timeout, **prep.method_args)
+
+    echo_success(
+        "Action completed",
+        details=asdict(result),
+    )

--- a/src/nova_act/cli/browser/commands/browsing/fill_form.py
+++ b/src/nova_act/cli/browser/commands/browsing/fill_form.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fill-form command — fill out a form using JSON field data with per-field resolution."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("fill-form")
+@click.argument("json_data")
+@click.option("--submit", "submit_form", is_flag=True, default=False, help="Submit the form after filling")
+@click.option("--focus", help="Focus on a specific form area")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for the act_get() call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def fill_form(
+    json_data: str,
+    submit_form: bool,
+    focus: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Fill out a form on the current page using JSON field data.
+
+    JSON_DATA is a JSON object mapping field names/selectors to values.
+
+    Avoid passing sensitive credentials via CLI arguments as they may appear in shell history.
+
+    Examples:
+        act browser fill-form '{"Full Name": "John Smith", "Email": "john@example.com"}'
+        act browser fill-form '{"search_query": "example", "quantity": "1"}' --submit
+        act browser fill-form '{"#search": "test query"}' --focus "the search form"
+    """
+    try:
+        fields = json.loads(json_data)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(fields, dict):
+        raise click.BadParameter("JSON_DATA must be a JSON object (dict), not a list or scalar.")
+
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "fill_form", prep.manager, prep.session_info, params, log_args={"json_data": json_data, "submit": submit_form}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.fill_form(fields, submit=submit_form, focus=focus, timeout=timeout, **prep.method_args)
+
+    echo_success(
+        "Form filled",
+        details={k: v for k, v in asdict(result).items() if k != "instruction"},
+    )

--- a/src/nova_act/cli/browser/commands/browsing/forward.py
+++ b/src/nova_act/cli/browser/commands/browsing/forward.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Forward command — navigate browser history forward."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def forward(params: CommandParams) -> None:
+    """Go forward one page in browser history (Playwright go_forward).
+
+    Examples:
+        act browser forward
+        act browser forward --session-id my-session
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("forward", prep.manager, prep.session_info, params, log_args={}) as nova_act:
+        page = get_active_page(nova_act, prep.session_info)
+        page.go_forward(wait_until="commit")
+        url = page.url
+        title = page.title()
+
+    echo_success("Navigated forward", details={"URL": url, "Title": title})

--- a/src/nova_act/cli/browser/commands/browsing/goto.py
+++ b/src/nova_act/cli/browser/commands/browsing/goto.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Goto command for browser CLI — raw Playwright navigation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.browser.utils.validation_utils import (
+    require_argument,
+    warn_missing_protocol,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+def _validate_url(url: str | None) -> str:
+    """Validate and prepare URL for navigation."""
+    require_argument(url, "URL", "act browser goto https://example.com")
+    if url is None:
+        raise ValueError("URL is required")
+    warn_missing_protocol(url)
+    return url
+
+
+@click.command()
+@click.argument("url", required=False)
+@click.option("--timeout", type=int, help="Navigation timeout in seconds (default: 30)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def goto(
+    url: str | None,
+    timeout: int | None,
+    params: CommandParams,
+) -> None:
+    """Navigate to a URL (raw Playwright go_to_url).
+
+    Examples:
+        act browser goto https://amazon.com
+        act browser goto https://example.com --session-id my-session
+        act browser goto https://example.com --timeout 60
+    """
+    validated_url = _validate_url(url)
+    prep = prepare_session(params, validated_url)
+
+    with command_session(
+        "goto", prep.manager, prep.session_info, params, log_args={"url": validated_url, "timeout": timeout}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        actions.goto(validated_url, timeout=timeout)
+        title = get_active_page(nova_act, prep.session_info).title()
+
+    echo_success(
+        f"Navigated to {validated_url}",
+        details={"URL": validated_url, "Title": title},
+    )

--- a/src/nova_act/cli/browser/commands/browsing/network_log.py
+++ b/src/nova_act/cli/browser/commands/browsing/network_log.py
@@ -1,0 +1,152 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Network-log command — display captured network requests/responses."""
+
+from __future__ import annotations
+
+import json as _json
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.network_capture import (
+    NetworkCaptureService,
+    NetworkEntry,
+)
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import echo_success, get_cli_stdout
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+# Module-level registry: session_id -> NetworkCaptureService
+_capture_registry: dict[str, NetworkCaptureService] = {}
+
+
+def get_or_create_capture(session_id: str) -> NetworkCaptureService:
+    """Get existing capture service or create a new one for the session."""
+    if session_id not in _capture_registry:
+        _capture_registry[session_id] = NetworkCaptureService()
+    return _capture_registry[session_id]
+
+
+def _entry_to_dict(entry: NetworkEntry) -> dict[str, object]:
+    result: dict[str, object] = {
+        "method": entry.method,
+        "url": entry.url,
+        "status": entry.status,
+        "resource_type": entry.resource_type,
+        "duration_ms": entry.duration_ms,
+        "size": entry.size,
+    }
+    if entry.failed:
+        result["failed"] = True
+        result["failure_text"] = entry.failure_text
+    return result
+
+
+def _format_entry_line(entry: NetworkEntry) -> str:
+    status = str(entry.status) if entry.status else ("FAIL" if entry.failed else "---")
+    duration = f"{entry.duration_ms}ms" if entry.duration_ms is not None else "---"
+    return f"{entry.method:<6} {status:<5} {duration:<10} {entry.resource_type:<12} {entry.url}"
+
+
+@click.command("network-log")
+@click.option("--filter", "url_filter", default=None, help="Glob pattern to filter URLs (e.g. '*api*')")
+@click.option("--method", default=None, help="Filter by HTTP method (GET, POST, etc.)")
+@click.option("--status", default=None, help="Filter by status code (200, 4xx, 5xx, >=400)")
+@click.option("--limit", default=50, type=int, help="Max entries to display (default: 50)")
+@click.option("--clear", is_flag=True, help="Clear captured entries")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def network_log(
+    url_filter: str | None,
+    method: str | None,
+    status: str | None,
+    limit: int,
+    clear: bool,
+    params: CommandParams,
+) -> None:
+    """Display captured network requests and responses.
+
+    Captures HTTP traffic using Playwright event listeners. On first call,
+    starts monitoring. Subsequent calls display accumulated entries.
+
+    Examples:
+        act browser network-log
+        act browser network-log --filter "*api*" --method POST
+        act browser network-log --status 4xx --limit 20
+        act browser network-log --clear
+        act browser network-log --json
+    """
+    prep = prepare_session(params, None)
+    capture = get_or_create_capture(params.session_id)
+
+    with command_session("network-log", prep.manager, prep.session_info, params) as nova_act:
+        # Attach capture if not already attached
+        if not capture.is_attached:
+            capture.attach(get_active_page(nova_act, prep.session_info))
+            if clear:
+                capture.clear()
+                echo_success("Network capture started and cleared")
+                return
+            echo_success(
+                "Network monitoring started",
+                details={"message": "Run commands, then re-run network-log to see traffic"},
+            )
+            return
+
+        if clear:
+            capture.clear()
+            echo_success("Network log cleared")
+            return
+
+        entries = capture.get_entries(url_filter=url_filter, method=method, status=status, limit=limit)
+        _emit_entries(entries, capture.entry_count, params.session_id)
+
+
+def _emit_entries(entries: list[NetworkEntry], total: int, session_id: str) -> None:
+    """Output entries in JSON or text format."""
+    out = get_cli_stdout()
+    if is_json_mode():
+        payload = {
+            "status": "success",
+            "data": {
+                "total_captured": total,
+                "showing": len(entries),
+                "entries": [_entry_to_dict(e) for e in entries],
+            },
+        }
+        click.echo(_json.dumps(payload), file=out)
+    else:
+        click.echo("status: success", file=out)
+        click.echo(f"total_captured: {total}", file=out)
+        click.echo(f"showing: {len(entries)}", file=out)
+        if entries:
+            click.echo(f"{'METHOD':<6} {'CODE':<5} {'DURATION':<10} {'TYPE':<12} URL", file=out)
+            for entry in entries:
+                click.echo(_format_entry_line(entry), file=out)
+        else:
+            click.echo("No matching entries", file=out)

--- a/src/nova_act/cli/browser/commands/browsing/page.py
+++ b/src/nova_act/cli/browser/commands/browsing/page.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Page Playwright passthrough command for direct page API access."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+
+def _get_page_signatures(page: object) -> str:
+    """Introspect the page object and return method signatures with type hints."""
+    lines: list[str] = []
+    for name in sorted(dir(page)):
+        if name.startswith("_"):
+            continue
+        attr = getattr(page, name, None)
+        if attr is None or not callable(attr):
+            continue
+        try:
+            sig = inspect.signature(attr)
+            lines.append(f"{name}{sig}")
+        except (ValueError, TypeError):
+            lines.append(name)
+    return "\n".join(lines)
+
+
+def _call_method(page: object, method_name: str, kwargs: dict[str, object]) -> object:
+    """Call a method on the page object, awaiting if it returns a coroutine."""
+    method = getattr(page, method_name)
+    result = method(**kwargs)
+    if asyncio.iscoroutine(result):
+        loop = asyncio.new_event_loop()
+        result = loop.run_until_complete(result)
+        loop.close()
+    return result
+
+
+@click.command()
+@click.argument("method_name", required=False, default=None)
+@click.option("--kwargs", "kwargs_json", default=None, help="JSON string of keyword arguments for the method")
+@click.option("--signatures", is_flag=True, default=False, help="List available page methods with type hints")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def page(
+    method_name: str | None,
+    kwargs_json: str | None,
+    signatures: bool,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Call any method on the Playwright page object directly.
+
+    Provides full passthrough access to the Playwright page API. Use --signatures
+    to discover available methods.
+
+    Examples:
+        act browser page go_back --session-id my-session
+        act browser page reload --session-id my-session
+        act browser page goto --kwargs '{"url": "https://example.com"}'
+        act browser page set_viewport_size --kwargs '{"viewport_size": {"width": 1920, "height": 1080}}'
+        act browser page --signatures
+    """
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "page", prep.manager, prep.session_info, params, log_args={"method_name": method_name}
+    ) as nova_act:
+        active_page = get_active_page(nova_act, prep.session_info)
+        if signatures:
+            sig_output = _get_page_signatures(active_page)
+            click.echo(sig_output)
+            return
+
+        if not method_name:
+            raise click.UsageError("method_name is required unless --signatures is used")
+
+        if not hasattr(active_page, method_name):
+            raise click.UsageError(f"Unknown page method: {method_name}")
+
+        kwargs: dict[str, object] = {}
+        if kwargs_json:
+            try:
+                kwargs = json.loads(kwargs_json)
+            except json.JSONDecodeError as e:
+                raise click.UsageError(f"Invalid JSON in --kwargs: {e}") from e
+            if not isinstance(kwargs, dict):
+                raise click.UsageError("--kwargs must be a JSON object")
+
+        result = _call_method(active_page, method_name, kwargs)
+
+        details: dict[str, object] = {}
+        if result is not None:
+            details["Result"] = str(result)
+
+        echo_success("Page method called", details=details)

--- a/src/nova_act/cli/browser/commands/browsing/refresh.py
+++ b/src/nova_act/cli/browser/commands/browsing/refresh.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Refresh command — reload the current page."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def refresh(params: CommandParams) -> None:
+    """Reload the current page (Playwright reload).
+
+    Examples:
+        act browser refresh
+        act browser refresh --session-id my-session
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("refresh", prep.manager, prep.session_info, params, log_args={}) as nova_act:
+        page = get_active_page(nova_act, prep.session_info)
+        page.reload(wait_until="load")
+        url = page.url
+        title = page.title()
+
+    echo_success("Page refreshed", details={"URL": url, "Title": title})

--- a/src/nova_act/cli/browser/commands/browsing/scroll_to.py
+++ b/src/nova_act/cli/browser/commands/browsing/scroll_to.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Scroll-to command — scroll to a target section on the current page."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import (
+    validate_prompt,
+    validate_starting_page,
+)
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("scroll-to")
+@click.argument("target")
+@click.option("--max-attempts", type=int, default=5, show_default=True, help="Max scroll+verify attempts")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for each act/act_get call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def scroll_to(
+    target: str,
+    max_attempts: int,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Scroll to a target section or content on the current page.
+
+    Iteratively scrolls and verifies whether the target content is visible.
+    Does NOT navigate to other pages — scrolling only.
+
+    \b
+    ⚠ Cost: Each attempt = 2 inference calls (scroll + verify). Default 5 attempts = up to 10 calls.
+
+    Examples:
+        act browser scroll-to "the pricing section" --session-id my-session
+        act browser scroll-to "the footer" --max-attempts 3
+        act browser scroll-to "the FAQ section" --starting-page https://example.com --json
+    """
+    validate_prompt(target)
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    try:
+        with command_session(
+            "scroll_to", prep.manager, prep.session_info, params, log_args={"target": target}
+        ) as nova_act:
+            actions = BrowserActions(nova_act)
+            result = actions.scroll_to(target, max_attempts=max_attempts, timeout=timeout, **prep.method_args)
+    except RuntimeError as e:
+        exit_with_error(
+            "Scroll target not found",
+            str(e),
+            suggestions=["Try increasing --max-attempts", "Try a more specific target description"],
+            error_code=ErrorCode.NAVIGATION_ERROR,
+            retryable=True,
+        )
+
+    details: dict[str, object] = {k: v for k, v in asdict(result).items() if k != "target"}
+    if result.attempts == 0:
+        details.pop("attempts", None)
+
+    if result.reached:
+        echo_success("Scroll target reached", details=details)
+    else:
+        exit_with_error(
+            "Scroll target not found",
+            f"Could not find '{target}' after {result.attempts} attempt(s)",
+            suggestions=["Try increasing --max-attempts", "Try a more specific target description"],
+            error_code=ErrorCode.NAVIGATION_ERROR,
+            retryable=True,
+        )

--- a/src/nova_act/cli/browser/commands/browsing/tab_close.py
+++ b/src/nova_act/cli/browser/commands/browsing/tab_close.py
@@ -1,0 +1,101 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tab-close command — close a browser tab."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("tab-close")
+@click.option("--tab-id", type=int, default=None, help="Index of tab to close (default: active tab)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def tab_close(tab_id: int | None, params: CommandParams) -> None:
+    """Close a browser tab by index, or the active tab if no index given.
+
+    After closing, switches to the nearest remaining tab.
+    Cannot close the last remaining tab.
+
+    Examples:
+        act browser tab-close
+        act browser tab-close --tab-id 2
+        act browser tab-close --session-id my-session --json
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("tab-close", prep.manager, prep.session_info, params, log_args={"tab_id": tab_id}) as nova_act:
+        pages = nova_act.page.context.pages
+        if len(pages) <= 1:
+            exit_with_error(
+                "Cannot close last tab",
+                "At least one tab must remain open",
+                suggestions=["Use 'session stop' to end the browser session instead"],
+                error_code=ErrorCode.VALIDATION_ERROR,
+            )
+
+        if tab_id is None:
+            target = get_active_page(nova_act, prep.session_info)
+            tab_id = list(pages).index(target)
+        else:
+            if tab_id < 0 or tab_id >= len(pages):
+                exit_with_error(
+                    "Invalid tab index",
+                    f"Index {tab_id} out of range (0-{len(pages) - 1})",
+                    suggestions=["Use 'tab-list' to see available tabs"],
+                    error_code=ErrorCode.VALIDATION_ERROR,
+                )
+            target = pages[tab_id]
+
+        closed_url = target.url
+        closed_title = target.title()
+        target.close()
+
+        # Switch to nearest remaining tab
+        remaining = nova_act.page.context.pages
+        new_index = min(tab_id, len(remaining) - 1)
+        remaining[new_index].bring_to_front()
+
+        # Persist new active tab index
+        prep.session_info.active_tab_index = new_index
+        prep.manager.save_session_metadata(prep.session_info)
+
+    echo_success(
+        "Tab closed",
+        details={
+            "closed_index": tab_id,
+            "closed_url": closed_url,
+            "closed_title": closed_title,
+            "new_active_index": new_index,
+        },
+    )

--- a/src/nova_act/cli/browser/commands/browsing/tab_list.py
+++ b/src/nova_act/cli/browser/commands/browsing/tab_list.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tab-list command — list all open browser tabs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("tab-list")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def tab_list(params: CommandParams) -> None:
+    """List all open browser tabs with index, URL, and title.
+
+    The active tab is marked with an asterisk (*).
+
+    Examples:
+        act browser tab-list
+        act browser tab-list --session-id my-session
+        act browser tab-list --json
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("tab-list", prep.manager, prep.session_info, params, log_args={}) as nova_act:
+        pages = nova_act.page.context.pages
+        active_page = get_active_page(nova_act, prep.session_info)
+        tabs = []
+        for i, p in enumerate(pages):
+            tabs.append(
+                {
+                    "index": i,
+                    "url": p.url,
+                    "title": p.title(),
+                    "active": p is active_page,
+                }
+            )
+
+    echo_success("Tabs listed", details={"tab_count": len(tabs), "tabs": tabs})

--- a/src/nova_act/cli/browser/commands/browsing/tab_new.py
+++ b/src/nova_act/cli/browser/commands/browsing/tab_new.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tab-new command — open a new browser tab."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("tab-new")
+@click.option("--url", default="about:blank", help="URL to open in the new tab (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def tab_new(url: str, params: CommandParams) -> None:
+    """Open a new browser tab, optionally navigating to a URL.
+
+    Creates a new tab in the current browser context and makes it active.
+
+    Examples:
+        act browser tab-new
+        act browser tab-new --url https://example.com
+        act browser tab-new --session-id my-session --json
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("tab-new", prep.manager, prep.session_info, params, log_args={"url": url}) as nova_act:
+        context = get_active_page(nova_act, prep.session_info).context
+        new_page = context.new_page()
+        if url != "about:blank":
+            new_page.goto(url)
+        new_page.bring_to_front()
+        pages = context.pages
+        index = list(pages).index(new_page)
+        tab_url = new_page.url
+        tab_title = new_page.title()
+
+        # Update active tab to the newly created tab
+        prep.session_info.active_tab_index = index
+        prep.manager.save_session_metadata(prep.session_info)
+
+    echo_success(
+        "New tab opened",
+        details={"index": index, "url": tab_url, "title": tab_title},
+    )

--- a/src/nova_act/cli/browser/commands/browsing/tab_select.py
+++ b/src/nova_act/cli/browser/commands/browsing/tab_select.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tab-select command — switch to a browser tab by index."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("tab-select")
+@click.argument("index", type=int)
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def tab_select(index: int, params: CommandParams) -> None:
+    """Switch to a browser tab by its index.
+
+    Use 'tab-list' to see available tab indices.
+
+    Examples:
+        act browser tab-select 0
+        act browser tab-select 2 --session-id my-session
+        act browser tab-select 1 --json
+    """
+    prep = prepare_session(params, None)
+
+    with command_session("tab-select", prep.manager, prep.session_info, params, log_args={"index": index}) as nova_act:
+        pages = nova_act.page.context.pages
+        if index < 0 or index >= len(pages):
+            exit_with_error(
+                "Invalid tab index",
+                f"Index {index} out of range (0-{len(pages) - 1})",
+                suggestions=["Use 'tab-list' to see available tabs"],
+                error_code=ErrorCode.VALIDATION_ERROR,
+            )
+        selected = pages[index]
+        selected.bring_to_front()
+        url = selected.url
+        title = selected.title()
+
+        # Persist active tab index so subsequent commands operate on this tab
+        prep.session_info.active_tab_index = index
+        prep.manager.save_session_metadata(prep.session_info)
+
+    echo_success(
+        "Tab selected",
+        details={"index": index, "url": url, "title": title},
+    )

--- a/src/nova_act/cli/browser/commands/browsing/type_text.py
+++ b/src/nova_act/cli/browser/commands/browsing/type_text.py
@@ -1,0 +1,84 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Type command — type text into a target element or focused element."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("type")
+@click.argument("text")
+@click.option(
+    "--target",
+    default=None,
+    help="Element to type into (natural language, CSS selector, or ref). If omitted, types into focused element.",
+)
+@click.option("--append", is_flag=True, default=False, help="Append to existing content instead of replacing")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def type_text(
+    text: str,
+    target: str | None,
+    append: bool,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Type text into a target element or the currently focused element.
+
+    If --target is omitted, types into the currently focused input field.
+
+    Examples:
+        act browser type "hello world" --target "search box"
+        act browser type "hello world"
+        act browser type "hello world" --target "#search-input"
+        act browser type "additional text" --target "search box" --append
+    """
+    validate_starting_page(starting_page)
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "type", prep.manager, prep.session_info, params, log_args={"text": text, "target": target, "append": append}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.type_text(text, target=target, append=append, timeout=timeout, **prep.method_args)
+
+        echo_success("Text typed", details={k: v for k, v in asdict(result).items() if k not in ("typed", "target")})

--- a/src/nova_act/cli/browser/commands/browsing/verify.py
+++ b/src/nova_act/cli/browser/commands/browsing/verify.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verify command — assert a condition on the current page with CI-friendly exit codes."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@click.argument("assertion")
+@click.option("--focus", help="Focus verification on a specific page area")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for the verification call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def verify(
+    assertion: str,
+    focus: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Assert a condition on the current page. Exit code 0 on pass, 1 on fail.
+
+    Uses AI to determine if ASSERTION is true on the page. Returns structured
+    pass/fail with evidence — ideal for CI/CD pipelines and test scripts.
+
+    Examples:
+        act browser verify "the login button is visible" --session-id my-session
+        act browser verify "the price is $29.99" --focus "the pricing section"
+        act browser verify "there are exactly 5 items in the cart" --json
+    """
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "verify", prep.manager, prep.session_info, params, log_args={"assertion": assertion, "focus": focus}
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.verify(assertion, focus=focus, timeout=timeout, **prep.method_args)
+
+    if result.passed:
+        echo_success("Assertion passed", details=asdict(result))
+    else:
+        exit_with_error(
+            "Assertion failed",
+            f"Assertion failed: {assertion}",
+            suggestions=[
+                "Check that the assertion text matches what appears on the page",
+                "Use --focus to narrow verification to a specific area",
+                "Use --json for structured output in CI pipelines",
+            ],
+            error_code=ErrorCode.ASSERTION_FAILED,
+            retryable=False,
+            details=asdict(result),
+        )

--- a/src/nova_act/cli/browser/commands/browsing/wait_for.py
+++ b/src/nova_act/cli/browser/commands/browsing/wait_for.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wait-for command — poll until a condition is met on the current page."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command("wait-for")
+@click.argument("condition")
+@click.option("--timeout", type=int, default=30, show_default=True, help="Maximum seconds to wait for the condition")
+@click.option(
+    "--interval", type=int, default=5, show_default=True, help="Seconds between polls. Each poll = 1 inference call"
+)
+@click.option("--focus", help="Focus polling on a specific page area")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def wait_for(
+    condition: str,
+    timeout: int,
+    interval: int,
+    focus: str | None,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Poll until a condition is met on the current page.
+
+    Each poll is one inference call that checks whether CONDITION is true.
+
+    \b
+    ⚠ Cost: Each poll = 1 inference call. A 30s timeout with 5s interval = up to 6 calls.
+
+    Examples:
+        act browser wait-for "the loading spinner is gone" --session-id my-session
+        act browser wait-for "results are visible" --timeout 60 --interval 10
+        act browser wait-for "the modal is open" --focus "the dialog area" --json
+    """
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    try:
+        with command_session(
+            "wait_for",
+            prep.manager,
+            prep.session_info,
+            params,
+            log_args={"condition": condition, "timeout": timeout, "interval": interval},
+        ) as nova_act:
+            actions = BrowserActions(nova_act)
+            result = actions.wait_for(
+                condition,
+                timeout=timeout,
+                interval=interval,
+                focus=focus,
+                per_call_timeout=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+                **prep.method_args,
+            )
+    except RuntimeError as e:
+        exit_with_error(
+            "Condition not met",
+            str(e),
+            suggestions=[
+                "Increase --timeout for slower pages",
+                "Adjust --interval to poll more or less frequently",
+                "Verify the condition text matches what appears on the page",
+            ],
+            error_code=ErrorCode.TIMEOUT_ERROR,
+            retryable=True,
+        )
+
+    if result.met:
+        echo_success(
+            "Condition met",
+            details=asdict(result),
+        )
+    else:
+        exit_with_error(
+            "Condition not met",
+            f"Condition '{condition}' was not met after {result.polls} poll(s) within {timeout}s timeout",
+            suggestions=[
+                "Increase --timeout for slower pages",
+                "Adjust --interval to poll more or less frequently",
+                "Verify the condition text matches what appears on the page",
+            ],
+            error_code=ErrorCode.TIMEOUT_ERROR,
+            retryable=True,
+        )

--- a/src/nova_act/cli/browser/commands/extraction/__init__.py
+++ b/src/nova_act/cli/browser/commands/extraction/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extraction and inspection commands.
+
+This package groups extraction-related commands:
+- get_content: retrieve page content
+- extract: AI-powered data extraction
+- screenshot: capture page screenshots
+- query: DOM element queries
+- style: CSS style inspection
+- evaluate: JavaScript evaluation
+- diff: page content diffing
+
+Note: Commands are NOT re-exported here to avoid shadowing submodule names,
+which breaks unittest.mock.patch() on Python 3.10. Import commands directly
+from their submodules (e.g., from nova_act.cli.browser.commands.extraction.extract import extract).
+"""

--- a/src/nova_act/cli/browser/commands/extraction/diff.py
+++ b/src/nova_act/cli/browser/commands/extraction/diff.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Diff command — observe page state before and after an action."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import validate_starting_page
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@click.argument("action")
+@click.option("--observe-prompt", help="Custom observation prompt (overrides default)")
+@click.option("--schema", help="JSON Schema for observation response (overrides default)")
+@click.option("--focus", help="Focus observations on a specific page area")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for each inference call",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def diff(
+    action: str,
+    observe_prompt: str | None,
+    schema: str | None,
+    focus: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Observe page state before and after an action.
+
+    Takes three inference calls: observe before, execute ACTION, observe after.
+
+    Examples:
+        act browser diff "Click the submit button" --session-id my-session
+        act browser diff "Toggle dark mode" --observe-prompt "What is the background color?" --json
+        act browser diff "Add item to cart" --focus "the cart icon" --starting-page https://example.com
+    """
+    validate_starting_page(starting_page)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "diff",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"action": action, "observe_prompt": observe_prompt, "focus": focus},
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        result = actions.diff(
+            action, observe=observe_prompt, schema=schema, focus=focus, timeout=timeout, **prep.method_args
+        )
+
+        echo_success(
+            "Diff complete",
+            details={k: v for k, v in asdict(result).items() if k != "action"},
+        )

--- a/src/nova_act/cli/browser/commands/extraction/evaluate.py
+++ b/src/nova_act/cli/browser/commands/extraction/evaluate.py
@@ -1,0 +1,147 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Evaluate command for browser CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import (
+    DEFAULT_EVALUATE_TIMEOUT_SECONDS,
+    BrowserActions,
+    is_complex_result,
+)
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    generate_output_path,
+    validate_output_dir,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.core.cli_stdout import get_cli_stdout
+from nova_act.cli.core.json_output import ErrorCode, is_json_mode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+EVALUATE_OUTPUT = OutputPathConfig("eval", "json")
+
+
+@click.command(name="evaluate")
+@click.argument("expression")
+@click.option("--output", "-o", help="Output file path (auto-generated for complex results if not specified)")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DEFAULT_EVALUATE_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Evaluation timeout in seconds",
+)
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def evaluate(
+    expression: str,
+    output: str | None,
+    timeout: int,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Evaluate a JavaScript expression in the current page context.
+
+    \b
+    ⚠️  SECURITY WARNING: This executes arbitrary JavaScript in the page context.
+    Only use expressions you trust. Malicious JS can access cookies, session
+    tokens, and page data.
+
+    Examples:
+        act browser evaluate "document.title"
+        act browser evaluate "1 + 1"
+        act browser evaluate "document.querySelectorAll('a').length" --json
+        act browser evaluate "window.location.href" --session-id my-session
+        act browser evaluate "[...document.querySelectorAll('a')].map(a => a.href)" --output links.json
+        act browser evaluate "longRunningFunction()" --timeout 60
+    """
+    if output:
+        validate_output_dir(output)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "evaluate",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"expression": expression, "output": output, "timeout": timeout},
+    ) as nova_act:
+        actions = BrowserActions(nova_act)
+        try:
+            result: object = actions.evaluate_js(expression, timeout=timeout)
+        except Exception as e:
+            if "Evaluation timed out" in str(e):
+                exit_with_error(
+                    "Evaluation timed out",
+                    f"JavaScript expression did not complete within {timeout}s.",
+                    suggestions=[
+                        "Increase --timeout for long-running expressions",
+                        "Simplify the expression",
+                    ],
+                    error_code=ErrorCode.BROWSER_ERROR,
+                )
+            raise
+
+        file_path = _resolve_file_path(output, result)
+        if file_path:
+            _write_result_to_file(file_path, result)
+
+        details = _build_details(params.session_id, expression, file_path, result)
+        echo_success("Expression evaluated", details=details)
+
+        if not is_json_mode() and not file_path:
+            click.echo(f"\n--- Result ---\n{result}", file=get_cli_stdout())
+
+
+def _resolve_file_path(output: str | None, result: object) -> str | None:
+    """Determine output file path: user-provided, auto-generated for complex results, or None."""
+    if output:
+        return output
+    if is_complex_result(result):
+        return generate_output_path(EVALUATE_OUTPUT.filename, EVALUATE_OUTPUT.ext)
+    return None
+
+
+def _write_result_to_file(file_path: str, result: object) -> None:
+    """Write evaluation result to file, formatting complex results as JSON."""
+    content = json.dumps(result, indent=2) if is_complex_result(result) else str(result)
+    write_output_file(file_path, content)
+
+
+def _build_details(session_id: str, expression: str, file_path: str | None, result: object) -> dict[str, object]:
+    """Build details dict for echo_success output."""
+    details: dict[str, object] = {}
+    if file_path:
+        details["file"] = file_path
+    else:
+        details["result"] = result if is_json_mode() else repr(result)
+    return details

--- a/src/nova_act/cli/browser/commands/extraction/extract.py
+++ b/src/nova_act/cli/browser/commands/extraction/extract.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extract command — delegate data extraction plans to the browser agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    format_result,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.validation_utils import (
+    require_argument,
+    validate_starting_page,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+EXTRACTION_OUTPUT = OutputPathConfig("extraction", "txt")
+
+
+@click.command()
+@click.argument("prompt", required=False)
+@click.option("--schema", help="JSON schema for structured extraction (supports 'bool', 'string', or full JSON)")
+@click.option(
+    "--timeout",
+    type=int,
+    default=DefaultBrowserConfig.DEFAULT_ACT_TIMEOUT_SECONDS,
+    show_default=True,
+    help="Timeout in seconds for the act_get() call",
+)
+@click.option("--format", "output_format", type=click.Choice(["json", "text"]), default="text", help="Output format")
+@click.option("--output", "-o", help="Output file path (auto-generated if not specified)")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def extract(
+    prompt: str | None,
+    schema: str | None,
+    timeout: int,
+    output_format: str,
+    output: str | None,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Extract structured data from the browser, potentially across multiple steps.
+
+    Describe what data you need and how to find it as a natural language plan.
+    The agent will navigate, interact, and extract — all from a single prompt.
+    Use --schema to constrain the output to a specific type (bool, string, or JSON).
+
+    Examples:
+        act browser extract "Go to amazon.com, search for laptops, and get the top 5 results"
+        act browser extract "Navigate to the pricing page and extract plan names" --schema string
+        act browser extract "Open the user profile and get all field values" --session-id my-session
+        act browser extract "Check if the checkout button is enabled" --schema bool
+        act browser extract "Get all product prices on this page" --format json -o prices.json
+        act browser extract "Get the article title and author" --starting-page https://example.com/blog
+        act browser extract "Get title" --nova-arg max_steps=3
+    """
+    require_argument(prompt, "prompt", "act browser extract 'Get all product prices'")
+    validate_starting_page(starting_page)
+    assert prompt is not None
+
+    prep = prepare_session(params, starting_page)
+
+    ext = "json" if output_format == "json" else "txt"
+    with command_session(
+        "extract",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"prompt": prompt, "schema": schema, "output": output},
+    ) as nova_act:
+        output = resolve_output_path(output, EXTRACTION_OUTPUT.filename, ext)
+        actions = BrowserActions(nova_act)
+        extraction_data = actions.extract(prompt, schema=schema, timeout=timeout, **prep.method_args)
+
+    formatted_result = format_result(extraction_data, output_format)
+    file_size = write_output_file(output, formatted_result)
+
+    details: dict[str, object] = {
+        "file": output,
+        "size": file_size,
+    }
+    if file_size < 4096:
+        details["content"] = Path(output).read_text()
+        details["content_truncated"] = False
+    echo_success("Extraction complete", details=details)

--- a/src/nova_act/cli/browser/commands/extraction/get_content.py
+++ b/src/nova_act/cli/browser/commands/extraction/get_content.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Get-content command for browser CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.timeout import temporary_timeout
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+CONTENT_OUTPUT = OutputPathConfig("content", "txt")
+
+FORMAT_EXTENSIONS = {"text": "txt", "html": "html", "markdown": "md"}
+
+
+@click.command(name="get-content")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "html", "markdown"]),
+    default="text",
+    help="Output format (default: text)",
+)
+@click.option("--output", "-o", help="Output file path (auto-generated if not specified)")
+@click.option("--timeout", type=int, help="Timeout in seconds")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def get_content(
+    output_format: str,
+    output: str | None,
+    timeout: int | None,
+    params: CommandParams,
+) -> None:
+    """Get the text content of the current page.
+
+    Examples:
+        act browser get-content
+        act browser get-content --session-id my-session
+        act browser get-content --format html
+        act browser get-content --format markdown --output page.md
+    """
+    prep = prepare_session(params, None)
+
+    ext = FORMAT_EXTENSIONS[output_format]
+    with command_session(
+        "get_content", prep.manager, prep.session_info, params, log_args={"format": output_format, "output": output}
+    ) as nova_act:
+        output = resolve_output_path(output, CONTENT_OUTPUT.filename, ext)
+        with temporary_timeout(nova_act, timeout):
+            actions = BrowserActions(nova_act)
+            content = actions.get_content(output_format)
+            size = write_output_file(output, content)
+            details: dict[str, object] = {
+                "file": output,
+                "size": size,
+            }
+            if size < 4096:
+                details["content"] = Path(output).read_text()
+                details["content_truncated"] = False
+            echo_success(
+                f"Content saved to {output}",
+                details=details,
+            )

--- a/src/nova_act/cli/browser/commands/extraction/pdf.py
+++ b/src/nova_act/cli/browser/commands/extraction/pdf.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PDF export command for browser CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+PDF_OUTPUT = OutputPathConfig("page", "pdf")
+
+
+@click.command()
+@click.option("--output", "-o", help="Output file path for PDF")
+@click.option(
+    "--format",
+    "paper_format",
+    type=click.Choice(["letter", "a4", "a3", "legal", "tabloid"]),
+    default="letter",
+    help="Paper format (default: letter)",
+)
+@click.option("--landscape", is_flag=True, default=False, help="Landscape orientation")
+@click.option("--print-background", is_flag=True, default=False, help="Include background graphics")
+@click.option(
+    "--scale",
+    type=click.FloatRange(0.1, 2.0),
+    default=1.0,
+    help="Scale factor 0.1-2.0 (default: 1.0)",
+)
+@click.option("--page-ranges", default=None, help="Page ranges to print (e.g. '1-3, 5')")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def pdf(
+    output: str | None,
+    paper_format: str,
+    landscape: bool,
+    print_background: bool,
+    scale: float,
+    page_ranges: str | None,
+    params: CommandParams,
+) -> None:
+    """Export the current page as a PDF.
+
+    Note: PDF export requires headless mode. Use --headless on session create.
+
+    Examples:
+        act browser pdf
+        act browser pdf --output report.pdf
+        act browser pdf --format a4 --landscape
+        act browser pdf --print-background --scale 0.8
+    """
+    prep = prepare_session(params, None)
+
+    with command_session(
+        "pdf",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"output": output, "format": paper_format},
+    ) as nova_act:
+        output = resolve_output_path(output, PDF_OUTPUT.filename, "pdf")
+        # Playwright expects: Letter, Legal, Tabloid, A3, A4
+        format_map = {"letter": "Letter", "legal": "Legal", "tabloid": "Tabloid", "a3": "A3", "a4": "A4"}
+        pdf_kwargs: dict[str, object] = {
+            "format": format_map[paper_format],
+            "landscape": landscape,
+            "print_background": print_background,
+            "scale": scale,
+        }
+        if page_ranges:
+            pdf_kwargs["page_ranges"] = page_ranges
+
+        pdf_bytes = get_active_page(nova_act, prep.session_info).pdf(**pdf_kwargs)  # type: ignore[arg-type]
+
+        write_output_file(output, pdf_bytes)
+
+        details: dict[str, str] = {
+            "File": output,
+            "Size": f"{len(pdf_bytes)} bytes",
+            "Landscape": "Yes" if landscape else "No",
+            "Scale": str(scale),
+        }
+        if print_background:
+            details["Background"] = "Yes"
+        if page_ranges:
+            details["Pages"] = page_ranges
+        echo_success(f"PDF saved to {output}", details=details)

--- a/src/nova_act/cli/browser/commands/extraction/perf.py
+++ b/src/nova_act/cli/browser/commands/extraction/perf.py
@@ -1,0 +1,150 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Perf command for collecting and displaying browser performance metrics."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.performance_collector import (
+    PerfData,
+    PerformanceCollector,
+    format_memory,
+    format_navigation,
+    format_paint,
+    format_resources,
+    format_vitals,
+)
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    validate_output_dir,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.cli_stdout import get_cli_stdout
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+PERF_OUTPUT = OutputPathConfig("perf", "json")
+
+METRIC_CHOICES = ["navigation", "resources", "vitals", "memory", "all"]
+
+
+@click.command(name="perf")
+@click.option(
+    "--metrics",
+    type=click.Choice(METRIC_CHOICES, case_sensitive=False),
+    default="all",
+    show_default=True,
+    help="Which metrics to collect",
+)
+@click.option("--output", "-o", help="Save full metrics to JSON file")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def perf(
+    metrics: str,
+    output: str | None,
+    params: CommandParams,
+) -> None:
+    """Collect and display browser performance metrics.
+
+    Collects Navigation Timing, Resource Timing, Core Web Vitals (LCP, CLS),
+    and Memory usage via the browser Performance API.
+
+    \b
+    Examples:
+        act browser perf
+        act browser perf --metrics vitals
+        act browser perf --metrics navigation --json
+        act browser perf --output report.json
+    """
+    if output:
+        validate_output_dir(output)
+
+    prep = prepare_session(params, None)
+
+    with command_session(
+        "perf",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"metrics": metrics, "output": output},
+    ) as nova_act:
+        collector = PerformanceCollector(get_active_page(nova_act, prep.session_info))
+        data = collector.collect_all()
+
+        # Filter to requested metrics
+        filtered = _filter_metrics(data, metrics)
+
+        if output:
+            write_output_file(output, json.dumps(filtered, indent=2))
+
+        details: dict[str, object] = {}
+        if output:
+            details["File"] = output
+        if is_json_mode():
+            details["data"] = filtered
+
+        echo_success("Performance metrics collected", details=details)
+
+        if not is_json_mode():
+            _print_human_readable(data, metrics)
+
+
+def _filter_metrics(data: PerfData, metrics: str) -> dict[str, object]:
+    """Return only the requested metric categories."""
+    if metrics == "all":
+        return dict(data)
+    return {metrics: data.get(metrics)}
+
+
+def _print_human_readable(data: PerfData, metrics: str) -> None:
+    """Print formatted performance report to stdout."""
+    stdout = get_cli_stdout()
+    sections: list[tuple[str, list[str]]] = []
+
+    if metrics in ("all", "navigation"):
+        sections.append(("Navigation Timing", format_navigation(data.get("navigation"))))
+        sections.append(("Paint Timing", format_paint(data.get("paint", []))))
+    if metrics in ("all", "resources"):
+        sections.append(("Resources", format_resources(data.get("resources", []))))
+    if metrics in ("all", "vitals"):
+        vitals = data.get("vitals")
+        if vitals:
+            sections.append(("Core Web Vitals", format_vitals(vitals)))
+    if metrics in ("all", "memory"):
+        sections.append(("Memory", format_memory(data.get("memory"))))
+
+    click.echo("", file=stdout)
+    for title, lines in sections:
+        click.echo(f"  {title}", file=stdout)
+        for line in lines:
+            click.echo(line, file=stdout)
+        click.echo("", file=stdout)

--- a/src/nova_act/cli/browser/commands/extraction/query.py
+++ b/src/nova_act/cli/browser/commands/extraction/query.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Query command for browser CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import ALL_PROPERTIES, BrowserActions
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.timeout import temporary_timeout
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+QUERY_OUTPUT = OutputPathConfig("query", "json")
+
+
+def _parse_properties(properties: str | None) -> tuple[str, ...]:
+    """Parse and validate the --properties filter."""
+    if not properties:
+        return ALL_PROPERTIES
+    requested = tuple(p.strip() for p in properties.split(","))
+    invalid = [p for p in requested if p not in ALL_PROPERTIES]
+    if invalid:
+        raise click.BadParameter(f"Invalid properties: {', '.join(invalid)}. " f"Allowed: {', '.join(ALL_PROPERTIES)}")
+    return requested
+
+
+@click.command(name="query")
+@click.argument("selector")
+@click.option("--output", "-o", help="Output file path (auto-generated if not specified)")
+@click.option("--properties", default=None, help="Comma-separated property filter (tag,text,visible,boundingBox)")
+@click.option("--timeout", type=int, help="Timeout in seconds")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def query(
+    selector: str,
+    output: str | None,
+    properties: str | None,
+    timeout: int | None,
+    starting_page: str | None,
+    params: CommandParams,
+) -> None:
+    """Query page elements matching a CSS selector.
+
+    Returns properties (tag, text, visible, boundingBox) for each matching element.
+
+    Examples:
+        act browser query "div.header"
+        act browser query "a[href]" --properties tag,text
+        act browser query "button" --json
+        act browser query "input" --session-id my-session --timeout 10
+        act browser query "h1" --output /tmp/headings.json
+    """
+    props = _parse_properties(properties)
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "query",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"selector": selector, "properties": properties, "output": output},
+    ) as nova_act:
+        output = resolve_output_path(output, QUERY_OUTPUT.filename, QUERY_OUTPUT.ext)
+        with temporary_timeout(nova_act, timeout):
+            actions = BrowserActions(nova_act)
+            elements = actions.query_dom(selector, props)
+            content = json.dumps(elements, indent=2, default=str)
+            file_size = write_output_file(output, content)
+            details: dict[str, object] = {
+                "file": output,
+                "count": len(elements),
+            }
+            if file_size < 4096:
+                details["content"] = Path(output).read_text()
+                details["content_truncated"] = False
+            echo_success(
+                f"Found {len(elements)} element(s) matching '{selector}'",
+                details=details,
+            )

--- a/src/nova_act/cli/browser/commands/extraction/screenshot.py
+++ b/src/nova_act/cli/browser/commands/extraction/screenshot.py
@@ -1,0 +1,141 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Screenshot command for browser CLI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.utils.browser_config_cli import DEFAULT_SCREENSHOT_QUALITY
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+SCREENSHOT_OUTPUT = OutputPathConfig("screenshot", "png")
+
+
+@click.command()
+@click.option("--output", "-o", help="Output file path for screenshot")
+@click.option("--full-page", is_flag=True, default=False, help="Capture full page (default: viewport only)")
+@click.option("--viewport-only", is_flag=True, default=False, help="Capture viewport only (inverse of --full-page)")
+@click.option(
+    "--format", "output_format", type=click.Choice(["png", "jpeg"]), default="png", help="Image format (default: png)"
+)
+@click.option(
+    "--quality",
+    type=click.IntRange(0, 100),
+    default=DEFAULT_SCREENSHOT_QUALITY,
+    help=f"JPEG quality 0-100 (default: {DEFAULT_SCREENSHOT_QUALITY})",
+)
+@click.option(
+    "--annotate", is_flag=True, default=False, help="Overlay bounding boxes and ref labels on interactive elements"
+)
+@click.option(
+    "--annotate-filter",
+    default=None,
+    help="Comma-separated roles to annotate (e.g. button,link). Default: all interactive roles",
+)
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def screenshot(
+    output: str | None,
+    full_page: bool,
+    viewport_only: bool,
+    output_format: str,
+    quality: int,
+    annotate: bool,
+    annotate_filter: str | None,
+    params: CommandParams,
+) -> None:
+    """Capture a screenshot of the current page.
+
+    Examples:
+        act browser screenshot
+        act browser screenshot --output screenshot.png
+        act browser screenshot --annotate
+        act browser screenshot --annotate --annotate-filter button,link
+        act browser screenshot --full-page --output fullpage.png
+    """
+    prep = prepare_session(params, None)
+
+    with command_session(
+        "screenshot",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"output": output, "format": output_format, "annotate": annotate},
+    ) as nova_act:
+        output = resolve_output_path(output, SCREENSHOT_OUTPUT.filename, output_format)
+        effective_full_page = False if viewport_only else full_page
+        actions = BrowserActions(nova_act)
+        screenshot_bytes = actions.screenshot(
+            full_page=effective_full_page, output_format=output_format, quality=quality
+        )
+
+        annotation_count = 0
+        if annotate:
+            from nova_act.cli.browser.services.intent_resolution.snapshot import (
+                flatten_snapshot,
+            )
+            from nova_act.cli.browser.services.screenshot_annotator import (
+                annotate_screenshot,
+                resolve_element_boxes,
+            )
+
+            active_page = get_active_page(nova_act, prep.session_info)
+            tree = active_page.accessibility.snapshot()
+            elements = flatten_snapshot(tree)
+
+            role_filter: frozenset[str] | None = None
+            if annotate_filter:
+                role_filter = frozenset(r.strip() for r in annotate_filter.split(","))
+
+            elements_with_boxes = resolve_element_boxes(active_page, elements, role_filter)
+            annotation_count = len(elements_with_boxes)
+            if elements_with_boxes:
+                screenshot_bytes = annotate_screenshot(screenshot_bytes, elements_with_boxes)
+
+        write_output_file(output, screenshot_bytes)
+
+        details: dict[str, str] = {
+            "file": output,
+            "size": str(len(screenshot_bytes)),
+            "format": output_format.upper(),
+            "full_page": "Yes" if effective_full_page else "No",
+        }
+        if output_format == "jpeg":
+            details["quality"] = str(quality)
+        if annotate:
+            details["annotations"] = f"{annotation_count} elements labeled"
+        echo_success(f"Screenshot saved to {output}", details=details)

--- a/src/nova_act/cli/browser/commands/extraction/snapshot.py
+++ b/src/nova_act/cli/browser/commands/extraction/snapshot.py
@@ -1,0 +1,146 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Snapshot command — capture accessibility tree with sequential refs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import click
+import yaml
+
+from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement, flatten_snapshot
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+SNAPSHOT_OUTPUT = OutputPathConfig("snapshot", "yaml")
+
+_DEFAULT_FUZZY_THRESHOLD = 70
+
+
+def _parse_filter(filter_str: str) -> dict[str, object]:
+    """Parse --filter JSON string and validate."""
+    try:
+        data: dict[str, object] = json.loads(filter_str)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(f"Invalid JSON: {exc}") from exc
+    if "keywords" not in data or not isinstance(data["keywords"], list):
+        raise click.BadParameter("Filter must contain 'keywords' list")
+    return data
+
+
+def _fuzzy_match_elements(
+    elements: list[SnapshotElement],
+    keywords: list[str],
+    threshold: int,
+) -> list[dict[str, object]]:
+    """Fuzzy match elements against keywords using rapidfuzz."""
+    try:
+        from rapidfuzz import fuzz
+    except ImportError:
+        # Fallback to simple substring matching
+        matched: list[SnapshotElement] = []
+        for el in elements:
+            fields = [getattr(el, "name", ""), getattr(el, "role", ""), getattr(el, "value", "")]
+            for kw in keywords:
+                if any(kw.lower() in (f or "").lower() for f in fields):
+                    matched.append(el)
+                    break
+        return [asdict(e) for e in matched]
+
+    result: list[dict[str, object]] = []
+    for el in elements:
+        fields = [getattr(el, "name", "") or "", getattr(el, "role", "") or "", getattr(el, "value", "") or ""]
+        for kw in keywords:
+            if any(fuzz.token_set_ratio(kw, f) >= threshold for f in fields if f):
+                result.append(asdict(el))
+                break
+    return result
+
+
+@click.command()
+@click.option("--output", "-o", help="Output file path (auto-generated if not specified)")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@click.option(
+    "--filter", "filter_str", default=None, help='Fuzzy filter: \'{"keywords": ["submit"], "threshold": 70}\''
+)
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def snapshot(
+    output: str | None,
+    starting_page: str | None,
+    filter_str: str | None,
+    params: CommandParams,
+) -> None:
+    """Capture the accessibility tree of the current page.
+
+    Returns a flattened list of elements with sequential refs (e1, e2, ...).
+    Output is written to a YAML file (auto-generated or specified with --output).
+
+    Examples:
+        act browser snapshot
+        act browser snapshot --output tree.yaml
+        act browser snapshot --json
+        act browser snapshot --filter '{"keywords": ["submit", "email"]}'
+        act browser snapshot --session-id my-session
+    """
+    filter_config = _parse_filter(filter_str) if filter_str else None
+
+    prep = prepare_session(params, starting_page)
+
+    with command_session("snapshot", prep.manager, prep.session_info, params, log_args={"output": output}) as nova_act:
+        output = resolve_output_path(output, SNAPSHOT_OUTPUT.filename, SNAPSHOT_OUTPUT.ext)
+        tree = get_active_page(nova_act, prep.session_info).accessibility.snapshot()
+        elements = flatten_snapshot(tree)
+        records = [asdict(e) for e in elements]
+        content = yaml.dump(records, default_flow_style=False, sort_keys=False)
+        size = write_output_file(output, content)
+
+    details: dict[str, object] = {
+        "file": output,
+        "size": size,
+        "elements": len(records),
+    }
+
+    if filter_config:
+        keywords = filter_config["keywords"]
+        threshold = filter_config.get("threshold", _DEFAULT_FUZZY_THRESHOLD)
+        if not isinstance(keywords, list) or not isinstance(threshold, int):
+            raise click.BadParameter("Filter must contain 'keywords' list and optional 'threshold' int")
+        matched = _fuzzy_match_elements(elements, keywords, threshold)
+        details["filter"] = {"keywords": keywords, "threshold": threshold}
+        details["matched_elements"] = matched
+        details["matched_count"] = len(matched)
+
+    echo_success(f"Snapshot saved to {output}", details=details)

--- a/src/nova_act/cli/browser/commands/extraction/style.py
+++ b/src/nova_act/cli/browser/commands/extraction/style.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Style command for browser CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.services.browser_actions import BrowserActions
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.file_output import (
+    OutputPathConfig,
+    resolve_output_path,
+    write_output_file,
+)
+from nova_act.cli.browser.utils.session import command_session, prepare_session
+from nova_act.cli.browser.utils.timeout import temporary_timeout
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+STYLE_OUTPUT = OutputPathConfig("style", "json")
+
+
+@click.command(name="style")
+@click.argument("selector")
+@click.argument("properties", nargs=-1)
+@click.option("--output", "-o", help="Output file path (auto-generated if not specified)")
+@click.option("--starting-page", help="Starting URL for new sessions (default: about:blank)")
+@click.option("--timeout", type=int, help="Timeout in seconds")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def style(
+    selector: str,
+    properties: tuple[str, ...],
+    output: str | None,
+    starting_page: str | None,
+    timeout: int | None,
+    params: CommandParams,
+) -> None:
+    """Get computed CSS styles for elements matching a selector.
+
+    If PROPERTIES are specified, returns only those CSS properties.
+    Otherwise returns all computed styles.
+
+    Examples:
+        act browser style "div.header"
+        act browser style "div.header" color font-size
+        act browser style "a[href]" color --json
+        act browser style "button" --session-id my-session
+        act browser style "div.header" --output styles.json
+    """
+    prep = prepare_session(params, starting_page)
+
+    with command_session(
+        "style", prep.manager, prep.session_info, params, log_args={"selector": selector, "output": output}
+    ) as nova_act:
+        output = resolve_output_path(output, STYLE_OUTPUT.filename, STYLE_OUTPUT.ext)
+        with temporary_timeout(nova_act, timeout):
+            actions = BrowserActions(nova_act)
+            try:
+                styles = actions.get_styles(selector, properties)
+            except ValueError as exc:
+                raise click.ClickException(str(exc)) from exc
+
+            file_size = write_output_file(output, json.dumps(styles, indent=2))
+
+        details = _build_details(params.session_id, selector, len(styles), output, file_size)
+        echo_success(
+            f"Computed styles for {len(styles)} element(s) matching '{selector}'",
+            details=details,
+        )
+
+
+def _build_details(
+    session_id: str,
+    selector: str,
+    count: int,
+    file_path: str,
+    file_size: int,
+) -> dict[str, object]:
+    """Build details dict for echo_success output."""
+    details: dict[str, object] = {
+        "count": count,
+        "file": file_path,
+    }
+    if file_size < 4096:
+        details["content"] = Path(file_path).read_text()
+        details["content_truncated"] = False
+    return details

--- a/src/nova_act/cli/browser/commands/session/__init__.py
+++ b/src/nova_act/cli/browser/commands/session/__init__.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser session management commands.
+
+This package splits session commands by responsibility:
+- list: list_sessions command + display helpers
+- close: close + close_all commands + batch helpers
+- create: create command + validation
+- prune: prune command
+- record_show: display session recording manifest
+- trace_start / trace_stop: Playwright tracing
+
+Note: Click commands are imported with ``_cmd`` suffixes to avoid shadowing
+submodule names, which breaks ``unittest.mock.patch()`` on Python 3.10.
+"""
+
+import click
+
+from nova_act.cli.browser.commands.session.close import close as close_cmd
+from nova_act.cli.browser.commands.session.close import close_all as close_all_cmd
+from nova_act.cli.browser.commands.session.create import create as create_cmd
+from nova_act.cli.browser.commands.session.export import export as export_cmd
+from nova_act.cli.browser.commands.session.list import (
+    _format_session_details,
+)
+from nova_act.cli.browser.commands.session.list import list_sessions as list_sessions_cmd
+from nova_act.cli.browser.commands.session.prune import prune as prune_cmd
+from nova_act.cli.browser.commands.session.record_show import record_show as record_show_cmd
+from nova_act.cli.browser.commands.session.trace_start import trace_start as trace_start_cmd
+from nova_act.cli.browser.commands.session.trace_stop import trace_stop as trace_stop_cmd
+from nova_act.cli.group import StyledGroup
+
+
+@click.group(cls=StyledGroup)
+def session() -> None:
+    """Manage browser sessions."""
+    pass
+
+
+# Register session subcommands
+session.add_command(list_sessions_cmd)
+session.add_command(close_cmd)
+session.add_command(close_all_cmd)
+session.add_command(create_cmd)
+session.add_command(export_cmd)
+session.add_command(prune_cmd)
+session.add_command(record_show_cmd)
+session.add_command(trace_start_cmd)
+session.add_command(trace_stop_cmd)
+
+__all__ = [
+    "session",
+    "_format_session_details",
+]

--- a/src/nova_act/cli/browser/commands/session/close.py
+++ b/src/nova_act/cli/browser/commands/session/close.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session close and close-all commands."""
+
+import click
+
+from nova_act.cli.browser.services.session.manager import SessionManager
+from nova_act.cli.browser.services.session.models import SessionInfo
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.browser.utils.session import get_session_manager
+from nova_act.cli.core.exceptions import SessionNotFoundError
+from nova_act.cli.core.json_output import ErrorCode, is_json_mode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+
+def _close_single_session(manager: SessionManager, session_id: str, force: bool) -> None:
+    """Close a single session with comprehensive error handling.
+
+    Args:
+        manager: SessionManager instance
+        session_id: ID of session to close
+        force: Whether to force close without stopping browser
+
+    Raises:
+        click.exceptions.Exit: On any error during session closure
+    """
+    try:
+        manager.close_session(session_id, force=force)
+    except SessionNotFoundError:
+        exit_with_error(
+            f"Session '{session_id}' not found",
+            "The specified session does not exist",
+            suggestions=["List active sessions: act browser session list", "Check the session ID spelling"],
+            error_code=ErrorCode.SESSION_NOT_FOUND,
+        )
+    except RuntimeError as e:
+        exit_with_error(
+            f"Failed to close session '{session_id}'",
+            str(e),
+            suggestions=[
+                "Check if the browser is still running",
+                "Try again",
+                "Use '--force' flag to force close: act browser session close --force <session_id>",
+            ],
+            error_code=ErrorCode.BROWSER_ERROR,
+        )
+    except Exception as e:
+        exit_with_error(
+            f"Unexpected error closing session '{session_id}'",
+            str(e),
+            suggestions=["Try again", "Check system resources"],
+            error_code=ErrorCode.UNEXPECTED_ERROR,
+        )
+
+
+def _get_sessions_to_close(manager: SessionManager) -> list[SessionInfo]:
+    """Retrieve list of sessions to close.
+
+    Args:
+        manager: SessionManager instance
+
+    Returns:
+        List of session info objects
+
+    Raises:
+        click.exceptions.Exit: If unable to retrieve sessions
+    """
+    try:
+        return manager.list_sessions()
+    except Exception as e:
+        exit_with_error(
+            "Failed to close all sessions",
+            str(e),
+            suggestions=["Try again", "Close sessions individually: act browser session close <session-id>"],
+        )
+
+
+def _close_sessions_batch(
+    manager: SessionManager, sessions: list[SessionInfo], force: bool
+) -> tuple[list[str], list[str]]:
+    """Close multiple sessions and track results.
+
+    Args:
+        manager: SessionManager instance
+        sessions: List of sessions to close
+        force: Whether to force close
+
+    Returns:
+        Tuple of (closed_session_ids, failed_sessions)
+    """
+    closed_ids: list[str] = []
+    failed_sessions = []
+
+    for session in sessions:
+        if not is_json_mode():
+            click.echo(f"Closing session '{session.session_id}'...")
+        try:
+            manager.close_session(session.session_id, force=force)
+            closed_ids.append(session.session_id)
+        except Exception as e:
+            failed_sessions.append(f"{session.session_id}: {str(e)}")
+
+    return closed_ids, failed_sessions
+
+
+def _report_close_all_results(closed_ids: list[str], total_count: int, failed_sessions: list[str]) -> None:
+    """Report results of closing all sessions."""
+    if failed_sessions:
+        exit_with_error(
+            f"Closed {len(closed_ids)} of {total_count} sessions",
+            "Some sessions failed to close",
+            suggestions=[
+                "Failed sessions:",
+                *[f"  - {failure}" for failure in failed_sessions],
+                "Try closing failed sessions individually",
+            ],
+        )
+    else:
+        echo_success(
+            f"Closed all {len(closed_ids)} sessions",
+            details={"sessions_closed": closed_ids, "count": len(closed_ids)},
+        )
+
+
+@click.command()
+@click.option("--session-id", required=True, help="Session ID to close")
+@click.option("--force", is_flag=True, help="Force close without stopping browser (for orphaned sessions)")
+@json_option
+def close(session_id: str, force: bool) -> None:
+    """Close a specific browser session.
+
+    Examples:
+        act browser session close --session-id my-session
+        act browser session close --session-id default
+        act browser session close --session-id orphaned-session --force
+    """
+    manager = get_session_manager()
+    _close_single_session(manager, session_id, force)
+
+    status = "Force closed" if force else "Stopped"
+    echo_success(f"Closed session '{session_id}'", details={"Status": status})
+
+
+@click.command(name="close-all")
+@click.option("--force", is_flag=True, help="Force close without stopping browsers")
+@json_option
+def close_all(force: bool) -> None:
+    """Close all active browser sessions.
+
+    Examples:
+        act browser session close-all
+        act browser session close-all --force
+    """
+    manager = get_session_manager()
+    sessions = _get_sessions_to_close(manager)
+
+    if not sessions:
+        echo_success("No sessions to close", details={"Info": "No sessions found"})
+        return
+
+    # Force-close non-active sessions (FAILED/STOPPED) since they can't be gracefully stopped
+    closed_ids, failed_sessions = _close_sessions_batch(manager, sessions, force)
+    _report_close_all_results(closed_ids, len(sessions), failed_sessions)

--- a/src/nova_act/cli/browser/commands/session/create.py
+++ b/src/nova_act/cli/browser/commands/session/create.py
@@ -1,0 +1,88 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session create command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.auth import resolve_auth_mode
+from nova_act.cli.browser.utils.decorators import (
+    auth_options,
+    common_browser_options,
+    common_session_options,
+    json_option,
+    pack_command_params,
+    quiet_option,
+    verbose_option,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    build_browser_options_from_params,
+    get_or_create_session,
+    get_session_manager,
+)
+from nova_act.cli.browser.utils.validation_utils import (
+    validate_session_available,
+    warn_missing_protocol,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command()
+@click.argument("url")
+@common_browser_options
+@common_session_options
+@auth_options
+@click.option("--max-sessions", type=int, default=None, help="Maximum active sessions allowed (default: 5)")
+@json_option
+@quiet_option
+@verbose_option
+@handle_common_errors
+@pack_command_params
+def create(
+    url: str,
+    max_sessions: int | None,
+    params: CommandParams,
+) -> None:
+    """Create a new browser session starting at a specific URL.
+
+    Examples:
+        act browser session create https://example.com
+        act browser session create https://amazon.com --session-id my-session
+        act browser session create https://example.com --nova-arg headless=false
+        act browser session create https://example.com --headed
+        act browser session create https://example.com --headless
+        act browser session create https://example.com --max-sessions 10
+    """
+    warn_missing_protocol(url)
+    manager = get_session_manager()
+    validate_session_available(params.session_id, manager)
+
+    auth_config = resolve_auth_mode(params.auth_mode, params.profile, params.region, params.workflow_name)
+    browser_options = build_browser_options_from_params(
+        params,
+        auth_config=auth_config,
+    )
+    session_info = get_or_create_session(manager, params.session_id, url, browser_options, max_sessions=max_sessions)
+
+    echo_success(
+        f"Created session '{params.session_id}'",
+        details={"State": session_info.state.value},
+    )

--- a/src/nova_act/cli/browser/commands/session/export.py
+++ b/src/nova_act/cli/browser/commands/session/export.py
@@ -1,0 +1,354 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session export command — export structured session history for agent consumption."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import shutil
+from pathlib import Path
+
+import click
+import yaml
+
+from nova_act.cli.browser.services.session_recorder import CommandEntry, SessionManifest, get_recorder
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.core.output import echo_success, exit_with_error, get_cli_stdout
+
+logger = logging.getLogger(__name__)
+
+# Commands that use AI inference (act/act_get under the hood)
+AI_COMMANDS = frozenset(
+    {"execute", "ask", "fill_form", "fill-form", "scroll_to", "scroll-to", "wait_for", "wait-for", "verify"}
+)
+
+
+def _classify_command(command_name: str) -> str:
+    """Classify a command as ai_command or playwright_operation."""
+    normalized = command_name.replace("-", "_")
+    return "ai_command" if normalized in {c.replace("-", "_") for c in AI_COMMANDS} else "playwright_operation"
+
+
+def _enrich_entry(entry: CommandEntry) -> CommandEntry:
+    """Add type classification and hints to a manifest entry."""
+    cmd = entry.get("command", "")
+    cmd_type = _classify_command(cmd)
+    enriched: CommandEntry = {
+        "command": cmd,
+        "type": cmd_type,
+        "args": entry.get("args", {}),
+        "timestamp": entry.get("timestamp", ""),
+    }
+    if "duration_ms" in entry:
+        enriched["duration_ms"] = entry["duration_ms"]
+    if entry.get("result_summary"):
+        enriched["result"] = entry["result_summary"]
+    if cmd_type == "ai_command" and entry.get("steps_file"):
+        enriched["steps_file"] = entry["steps_file"]
+        # Try to load steps summary inline
+        try:
+            steps_path = Path(entry["steps_file"])
+            if steps_path.exists():
+                enriched["steps_summary"] = yaml.safe_load(steps_path.read_text())
+        except Exception:
+            pass
+    if entry.get("screenshots"):
+        enriched["screenshots"] = entry["screenshots"]
+    if entry.get("log_file"):
+        enriched["log_file"] = entry["log_file"]
+    return enriched
+
+
+def _embed_screenshots(entry: CommandEntry) -> CommandEntry:
+    """Embed screenshot files as base64 in the entry."""
+    screenshots = entry.get("screenshots", {})
+    if not screenshots:
+        return entry
+    embedded: dict[str, str] = {}
+    for key, path_str in screenshots.items():
+        if not path_str:
+            continue
+        p = Path(path_str)
+        if p.exists() and p.suffix in (".png", ".jpg", ".jpeg"):
+            try:
+                embedded[key] = base64.b64encode(p.read_bytes()).decode("ascii")
+            except Exception:
+                embedded[key] = f"<error reading {path_str}>"
+        else:
+            embedded[key] = str(path_str)  # keep path reference if file missing
+    if embedded:
+        entry = CommandEntry(**entry)
+        entry["screenshots_base64"] = embedded
+    return entry
+
+
+def _build_export(manifest: SessionManifest, include_screenshots: bool) -> dict[str, object]:
+    """Build the full export payload from a recorder manifest."""
+    commands = manifest["commands"]
+    enriched = [_enrich_entry(e) for e in commands]
+    if include_screenshots:
+        enriched = [_embed_screenshots(e) for e in enriched]
+
+    total_duration_ms = sum(e.get("duration_ms", 0) for e in enriched)
+    return {
+        "session_id": manifest.get("session_id", ""),
+        "created_at": manifest.get("started_at", ""),
+        "total_commands": len(enriched),
+        "total_duration_ms": round(total_duration_ms, 1),
+        "commands": enriched,
+    }
+
+
+def _copy_resource(src_path: str, dest_dir: Path) -> str | None:
+    """Copy a resource file into dest_dir. Returns relative path from report root, or None if missing."""
+    src = Path(src_path)
+    if not src.exists():
+        return None
+    dest = dest_dir / src.name
+    # Handle name collisions by appending a counter
+    counter = 1
+    while dest.exists():
+        dest = dest_dir / f"{src.stem}_{counter}{src.suffix}"
+        counter += 1
+    shutil.copy2(str(src), str(dest))
+    return f"{dest_dir.name}/{dest.name}"
+
+
+def _build_metadata_section(export_data: dict[str, object]) -> list[str]:
+    """Build the metadata section of the markdown report."""
+    sid = export_data.get("session_id", "unknown")
+    total_ms = export_data.get("total_duration_ms", 0)
+    assert isinstance(total_ms, (int, float))
+    return [
+        f"# Session Report: {sid}",
+        "",
+        "## Session Metadata",
+        "",
+        f"- **Session ID**: {sid}",
+        f"- **Created**: {export_data.get('created_at', 'N/A')}",
+        f"- **Total Commands**: {export_data.get('total_commands', 0)}",
+        f"- **Total Duration**: {total_ms}ms ({total_ms / 1000:.1f}s)",
+        "",
+    ]
+
+
+def _build_command_section(index: int, cmd: CommandEntry, resources: dict[str, str | None]) -> list[str]:
+    """Build the markdown section for a single command."""
+    cmd_name = cmd.get("command", "unknown")
+    cmd_type = cmd.get("type", "unknown")
+    lines: list[str] = [
+        f"### {index + 1}. {cmd_name}",
+        "",
+        f"- **Type**: {cmd_type}",
+    ]
+    if cmd.get("timestamp"):
+        lines.append(f"- **Timestamp**: {cmd['timestamp']}")
+    if "duration_ms" in cmd:
+        lines.append(f"- **Duration**: {cmd['duration_ms']}ms")
+    if cmd.get("args"):
+        lines.append(f"- **Args**: `{json.dumps(cmd['args'])}`")
+    if cmd.get("result"):
+        lines.append(f"- **Result**: `{json.dumps(cmd['result'])}`")
+
+    # Resource references
+    if resources.get("steps_file"):
+        lines.append(f"- **Steps**: [{resources['steps_file']}]({resources['steps_file']})")
+    elif cmd.get("steps_file"):
+        lines.append(f"- **Steps**: *(file not found: {cmd['steps_file']})*")
+
+    if resources.get("log_file"):
+        lines.append(f"- **Log**: [{resources['log_file']}]({resources['log_file']})")
+    elif cmd.get("log_file"):
+        lines.append(f"- **Log**: *(file not found: {cmd['log_file']})*")
+
+    for key, path_str in cmd.get("screenshots", {}).items():
+        rel = resources.get(f"screenshot_{key}")
+        if rel:
+            if rel.endswith((".png", ".jpg", ".jpeg")):
+                lines.append(f"- **{key}**: ![{key}]({rel})")
+            else:
+                lines.append(f"- **{key}**: [{rel}]({rel})")
+        else:
+            lines.append(f"- **{key}**: *(file not found: {path_str})*")
+
+    lines.append("")
+    return lines
+
+
+def _generate_report_markdown(
+    export_data: dict[str, object], copied_resources: dict[int, dict[str, str | None]]
+) -> str:
+    """Generate a structured markdown report from export data and copied resource paths."""
+    lines = _build_metadata_section(export_data)
+
+    commands = export_data.get("commands", [])
+    assert isinstance(commands, list)
+    if not commands:
+        lines.append("*No commands recorded.*")
+        return "\n".join(lines)
+
+    lines.append("## Commands")
+    lines.append("")
+
+    for i, cmd in enumerate(commands):
+        lines.extend(_build_command_section(i, cmd, copied_resources.get(i, {})))
+
+    return "\n".join(lines)
+
+
+def _copy_command_resources(
+    cmd: CommandEntry,
+    screenshots_dir: Path,
+    steps_dir: Path,
+    logs_dir: Path,
+) -> dict[str, str | None]:
+    """Copy a single command's resource files into the report directory structure.
+
+    Returns a dict mapping resource keys to their relative paths from the report root.
+    """
+    resources: dict[str, str | None] = {}
+
+    if cmd.get("steps_file"):
+        steps_dir.mkdir(parents=True, exist_ok=True)
+        resources["steps_file"] = _copy_resource(cmd["steps_file"], steps_dir)
+
+    if cmd.get("log_file"):
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        resources["log_file"] = _copy_resource(cmd["log_file"], logs_dir)
+
+    for key, path_str in cmd.get("screenshots", {}).items():
+        if path_str:
+            screenshots_dir.mkdir(parents=True, exist_ok=True)
+            resources[f"screenshot_{key}"] = _copy_resource(path_str, screenshots_dir)
+
+    return resources
+
+
+def _build_report(export_data: dict[str, object], output_dir: Path) -> str:
+    """Build a full report directory with markdown and copied resources. Returns the report path."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    screenshots_dir = output_dir / "screenshots"
+    steps_dir = output_dir / "steps"
+    logs_dir = output_dir / "logs"
+
+    copied_resources: dict[int, dict[str, str | None]] = {}
+    commands = export_data.get("commands", [])
+    assert isinstance(commands, list)
+    for i, cmd in enumerate(commands):
+        resources = _copy_command_resources(cmd, screenshots_dir, steps_dir, logs_dir)
+        if resources:
+            copied_resources[i] = resources
+
+    markdown = _generate_report_markdown(export_data, copied_resources)
+    report_path = output_dir / "report.md"
+    report_path.write_text(markdown, encoding="utf-8")
+    return str(report_path)
+
+
+@click.command(name="export")
+@click.option("--session-id", default="default", help="Session ID (default: 'default')")
+@click.option("--output", "-o", type=click.Path(), default=None, help="Save export to file")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "yaml"]),
+    default="json",
+    help="Output format (default: json)",
+)
+@click.option("--include-screenshots", is_flag=True, help="Embed screenshots as base64 (warning: large output)")
+@click.option("--report", is_flag=True, help="Generate a structured markdown report with copied resources")
+@click.option("--output-dir", type=click.Path(), default=None, help="Report output directory (requires --report)")
+@json_option
+def export(
+    session_id: str, output: str | None, fmt: str, include_screenshots: bool, report: bool, output_dir: str | None
+) -> None:
+    """Export structured session history for agent consumption.
+
+    Outputs every command executed in the session with type classification:
+    - ai_command: Commands using AI inference (execute, ask, verify, etc.)
+    - playwright_operation: Direct browser operations (goto, screenshot, etc.)
+
+    Examples:
+        act browser session export
+        act browser session export --session-id my-session --format json
+        act browser session export --output history.json --include-screenshots
+        act browser session export --format yaml -o history.yaml
+        act browser session export --report
+        act browser session export --report --output-dir ./my-report
+    """
+    # Validate flag combinations
+    if output_dir and not report:
+        exit_with_error(
+            "Invalid options",
+            "--output-dir requires --report",
+            suggestions=["Add --report flag: act browser session export --report --output-dir ./my-report"],
+        )
+
+    if report and fmt != "json":
+        exit_with_error(
+            "Invalid options",
+            "--report cannot be combined with --format (report always outputs markdown)",
+            suggestions=["Remove --format flag when using --report"],
+        )
+
+    recorder = get_recorder(session_id)
+    manifest = recorder.get_manifest()
+    commands = manifest["commands"]
+
+    if report:
+        # Build export data (no base64 embedding — we copy files instead)
+        payload = _build_export(manifest, include_screenshots=False)
+        report_dir = Path(output_dir) if output_dir else Path(f"./{session_id}_report")
+        report_path = _build_report(payload, report_dir)
+        echo_success(
+            f"Report generated at {report_path}",
+            details={
+                "session_id": session_id,
+                "commands": len(commands),
+                "output_dir": str(report_dir),
+            },
+        )
+        return
+
+    if not commands:
+        echo_success("No commands recorded", details={"session_id": session_id})
+        return
+
+    if include_screenshots:
+        click.echo("⚠ --include-screenshots embeds image data as base64. Output may be very large.", err=True)
+
+    payload = _build_export(manifest, include_screenshots)
+
+    # Serialize
+    if fmt == "yaml":
+        serialized = yaml.dump(payload, default_flow_style=False, sort_keys=False)
+    else:
+        serialized = json.dumps(payload, indent=2)
+
+    # Output
+    if output:
+        Path(output).write_text(serialized, encoding="utf-8")
+        echo_success(
+            f"Session exported to {output}",
+            details={
+                "session_id": session_id,
+                "commands": len(commands),
+            },
+        )
+    else:
+        out = get_cli_stdout()
+        click.echo(serialized, file=out)

--- a/src/nova_act/cli/browser/commands/session/list.py
+++ b/src/nova_act/cli/browser/commands/session/list.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session list command and display helpers."""
+
+import click
+
+from nova_act.cli.browser.services.session.manager import filter_active_sessions
+from nova_act.cli.browser.services.session.models import SessionInfo
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.browser.utils.session import get_session_manager
+from nova_act.cli.core.constants import DEFAULT_DATETIME_FORMAT
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import echo_success, exit_with_error
+
+
+def _format_session_details(sessions: list[SessionInfo]) -> dict[str, str]:
+    """Format session information for human-readable display.
+
+    Args:
+        sessions: List of sessions to format
+
+    Returns:
+        Dictionary mapping session labels to formatted details
+    """
+    details = {}
+    for session in sessions:
+        parts = [session.state.value, f"Created: {session.created_at.strftime(DEFAULT_DATETIME_FORMAT)}"]
+        if session.last_used:
+            parts.append(f"Last used: {session.last_used.strftime(DEFAULT_DATETIME_FORMAT)}")
+        details[f"Session '{session.session_id}'"] = " | ".join(parts)
+    return details
+
+
+def _display_empty_sessions(show_all: bool) -> None:
+    """Display message when no sessions exist."""
+    status_msg = "No sessions" if show_all else "No active browser sessions"
+    if is_json_mode():
+        echo_success(status_msg, details={"sessions": []})
+    else:
+        echo_success(status_msg, details={"Info": "Use 'act browser session create <url>' to start a session"})
+
+
+def _display_sessions(sessions: list[SessionInfo], show_all: bool) -> None:
+    """Display formatted session list."""
+    status_msg = f"Sessions ({len(sessions)})" if show_all else f"Active browser sessions ({len(sessions)})"
+    if is_json_mode():
+        echo_success(status_msg, details={"sessions": [s.to_dict() for s in sessions]})
+    else:
+        echo_success(status_msg, details=_format_session_details(sessions))
+
+
+@click.command(name="list")
+@click.option("--all", "show_all", is_flag=True, help="Show all sessions including stopped/failed")
+@json_option
+def list_sessions(show_all: bool) -> None:
+    """List active browser sessions.
+
+    By default, only shows active sessions (STARTING, STARTED).
+    Use --all to show all sessions including stopped/failed.
+
+    Examples:
+        act browser session list
+        act browser session list --all
+    """
+    manager = get_session_manager()
+
+    try:
+        sessions = manager.list_sessions()
+
+        if not show_all:
+            sessions = filter_active_sessions(sessions)
+
+        if not sessions:
+            _display_empty_sessions(show_all)
+            return
+
+        _display_sessions(sessions, show_all)
+
+    except Exception as e:
+        exit_with_error(
+            "Failed to list sessions", str(e), suggestions=["Check if session manager is accessible", "Try again"]
+        )

--- a/src/nova_act/cli/browser/commands/session/prune.py
+++ b/src/nova_act/cli/browser/commands/session/prune.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session prune command."""
+
+import click
+
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import get_session_manager
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import echo_success
+
+
+@click.command()
+@click.option("--ignore-ttl", is_flag=True, help="Prune all non-active sessions regardless of TTL")
+@click.option("--dry-run", is_flag=True, help="Preview what would be pruned without deleting")
+@json_option
+@handle_common_errors
+def prune(ignore_ttl: bool, dry_run: bool) -> None:
+    """Remove stale sessions and their Chrome profile directories.
+
+    By default, prunes sessions inactive for 24+ hours or with dead browser PIDs.
+    Use --ignore-ttl to prune all non-active (stopped/failed) sessions regardless of TTL.
+
+    Examples:
+        act browser session prune
+        act browser session prune --ignore-ttl
+        act browser session prune --dry-run
+    """
+    manager = get_session_manager()
+    results = manager.prune_sessions(ignore_ttl=ignore_ttl, dry_run=dry_run)
+
+    if not results:
+        if is_json_mode():
+            echo_success("No sessions to prune", details={"sessions_pruned": [], "count": 0})
+        else:
+            echo_success("No sessions to prune", details={"Info": "All sessions are active or within TTL"})
+        return
+
+    action = "Would prune" if dry_run else "Pruned"
+    if is_json_mode():
+        pruned = [{"session_id": r.session_id, "profile_dir": r.user_data_dir} for r in results]
+        echo_success(f"{action} {len(results)} session(s)", details={"sessions_pruned": pruned, "count": len(results)})
+    else:
+        details = {f"Session '{r.session_id}'": r.user_data_dir or "(no profile dir)" for r in results}
+        echo_success(f"{action} {len(results)} session(s)", details=details)

--- a/src/nova_act/cli/browser/commands/session/record_show.py
+++ b/src/nova_act/cli/browser/commands/session/record_show.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Record-show command — display session recording manifest."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from nova_act.cli.browser.services.session_recorder import (
+    get_recorder,
+)
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.core.output import echo_success, get_cli_stdout
+
+
+@click.command(name="record-show")
+@click.option("--session-id", default="default", help="Session ID (default: 'default')")
+@click.option("--limit", type=int, default=None, help="Show last N commands only")
+@click.option("--summary", is_flag=True, help="Condensed summary view")
+@json_option
+def record_show(session_id: str, limit: int | None, summary: bool) -> None:
+    """Display session recording manifest.
+
+    Shows all commands recorded in the session, with timestamps, durations,
+    and artifact paths. Use --json for structured output (critical for agents).
+
+    Examples:
+        act browser session record-show
+        act browser session record-show --session-id my-session
+        act browser session record-show --limit 5 --json
+        act browser session record-show --summary
+    """
+    recorder = get_recorder(session_id)
+    manifest = recorder.get_manifest()
+    commands = recorder.get_commands(limit=limit)
+
+    if not commands:
+        echo_success("No commands recorded", details={"session_id": session_id})
+        return
+
+    from nova_act.cli.core.json_output import is_json_mode
+
+    out = get_cli_stdout()
+    if is_json_mode():
+        output = {
+            "session_id": manifest.get("session_id"),
+            "started_at": manifest.get("started_at"),
+            "last_updated": manifest.get("last_updated"),
+            "total_commands": len(manifest.get("commands", [])),
+            "commands": commands,
+        }
+        click.echo(json.dumps(output, indent=2), file=out)
+        return
+
+    if summary:
+        echo_success(
+            f"Session recording ({len(commands)} commands)",
+            details={
+                "Started": manifest.get("started_at", "unknown"),
+                "Commands": ", ".join(c["command"] for c in commands),
+            },
+        )
+        return
+
+    # Detailed view
+    details: dict[str, str] = {
+        "Started": manifest.get("started_at", "unknown"),
+        "Total commands": str(len(manifest.get("commands", []))),
+    }
+    for i, cmd in enumerate(commands, 1):
+        duration = f" ({cmd['duration_ms']:.0f}ms)" if "duration_ms" in cmd else ""
+        details[f"  [{i}] {cmd['command']}"] = f"{cmd.get('timestamp', '')}{duration}"
+
+    echo_success(f"Session recording ({len(commands)} commands)", details=details)

--- a/src/nova_act/cli/browser/commands/session/trace_start.py
+++ b/src/nova_act/cli/browser/commands/session/trace_start.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trace-start command — begin Playwright tracing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command(name="trace-start")
+@click.option("--screenshots/--no-screenshots", default=True, help="Capture screenshots in trace (default: true)")
+@click.option("--snapshots/--no-snapshots", default=True, help="Capture DOM snapshots in trace (default: true)")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def trace_start(screenshots: bool, snapshots: bool, params: CommandParams) -> None:
+    """Start Playwright tracing for the current session.
+
+    Captures a detailed trace including screenshots, DOM snapshots, and network
+    activity. Stop with 'trace-stop' to save the trace file.
+
+    Examples:
+        act browser session trace-start
+        act browser session trace-start --no-screenshots
+    """
+    prep = prepare_session(params, None)
+
+    with command_session(
+        "trace-start",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"screenshots": screenshots, "snapshots": snapshots},
+    ) as nova_act:
+        get_active_page(nova_act, prep.session_info).context.tracing.start(screenshots=screenshots, snapshots=snapshots)
+
+    echo_success("Tracing started", details={"Screenshots": str(screenshots), "Snapshots": str(snapshots)})

--- a/src/nova_act/cli/browser/commands/session/trace_stop.py
+++ b/src/nova_act/cli/browser/commands/session/trace_stop.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trace-stop command — stop Playwright tracing and save trace file."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.browser.utils.decorators import (
+    browser_command_options,
+    pack_command_params,
+)
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.browser.utils.log_capture import get_log_dir
+from nova_act.cli.browser.utils.session import (
+    command_session,
+    get_active_page,
+    prepare_session,
+)
+from nova_act.cli.core.output import echo_success
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.types import CommandParams
+
+
+@click.command(name="trace-stop")
+@click.option("--output", "output_path", type=click.Path(), default=None, help="Output path for trace .zip file")
+@browser_command_options
+@handle_common_errors
+@pack_command_params
+def trace_stop(output_path: str | None, params: CommandParams) -> None:
+    """Stop Playwright tracing and save the trace file.
+
+    Saves a .zip trace file viewable with 'npx playwright show-trace <file>'.
+
+    Examples:
+        act browser session trace-stop
+        act browser session trace-stop --output ./my-trace.zip
+    """
+    prep = prepare_session(params, None)
+
+    if output_path is None:
+        log_dir = get_log_dir(params.session_id)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = str(log_dir / f"trace_{timestamp}.zip")
+
+    with command_session(
+        "trace-stop",
+        prep.manager,
+        prep.session_info,
+        params,
+        log_args={"output": output_path},
+    ) as nova_act:
+        get_active_page(nova_act, prep.session_info).context.tracing.stop(path=output_path)
+
+    echo_success("Tracing stopped", details={"Trace file": output_path})

--- a/src/nova_act/cli/browser/commands/setup/__init__.py
+++ b/src/nova_act/cli/browser/commands/setup/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup and diagnostic commands.
+
+This package groups setup-related commands:
+- setup: API key configuration
+- doctor: environment health checks
+
+Note: Commands are NOT re-exported here to avoid shadowing submodule names,
+which breaks unittest.mock.patch() on Python 3.10. Import commands directly
+from their submodules (e.g., from nova_act.cli.browser.commands.setup.setup import setup).
+"""

--- a/src/nova_act/cli/browser/commands/setup/cli_doctor.py
+++ b/src/nova_act/cli/browser/commands/setup/cli_doctor.py
@@ -1,0 +1,262 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLIDoctor: encapsulates all doctor check logic, result aggregation, and output formatting."""
+
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import click
+
+from nova_act.cli.browser.services.session.chrome_launcher import ChromeLauncher
+from nova_act.cli.browser.services.session.manager import SessionManager
+from nova_act.cli.browser.utils.auth import has_aws_credentials
+from nova_act.cli.browser.utils.log_capture import capture_command_log
+from nova_act.cli.core.config import get_session_dir, read_config
+from nova_act.cli.core.json_output import is_json_mode, json_success
+from nova_act.cli.core.output import get_cli_stdout
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Result of a single doctor check."""
+
+    name: str
+    status: str
+    message: str
+    fix: str | None = None
+
+
+_STATUS_ICONS = {
+    "pass": click.style("✓", fg="green"),
+    "fail": click.style("✗", fg="red"),
+    "info": click.style("ℹ", fg="yellow"),
+}
+
+
+class CLIDoctor:
+    """Encapsulates all doctor check logic, result aggregation, and output formatting."""
+
+    def _check_chrome(self) -> CheckResult:
+        """Check if Chrome/Chromium is installed and detectable."""
+        launcher = ChromeLauncher(session_dir="/tmp", get_used_ports_callback=lambda: set())
+        try:
+            path = launcher.detect_chrome_path()
+            return CheckResult(name="Chrome/Chromium found", status="pass", message=f"Found at {path}")
+        except RuntimeError:
+            return CheckResult(
+                name="Chrome/Chromium found",
+                status="fail",
+                message="Chrome/Chromium not found",
+                fix="Install Google Chrome or set CHROME_PATH environment variable",
+            )
+
+    def _check_auth(self) -> CheckResult:
+        """Check if any authentication method is configured (API key, config file, or AWS credentials)."""
+        if os.environ.get("NOVA_ACT_API_KEY"):
+            return CheckResult(
+                name="Authentication configured", status="pass", message="API key is configured (env var)"
+            )
+        try:
+            config = read_config()
+            if config.api_key:
+                return CheckResult(
+                    name="Authentication configured", status="pass", message="API key is configured (config file)"
+                )
+            if getattr(config, "aws_profile", None):
+                return CheckResult(
+                    name="Authentication configured",
+                    status="pass",
+                    message=f"AWS profile configured (config file): {config.aws_profile}",
+                )
+        except Exception:
+            logger.debug("Failed to read browser config", exc_info=True)
+        if has_aws_credentials(None):
+            return CheckResult(
+                name="Authentication configured",
+                status="pass",
+                message="AWS credentials are configured",
+            )
+        return CheckResult(
+            name="Authentication configured",
+            status="fail",
+            message="No authentication configured",
+            fix=(
+                "export NOVA_ACT_API_KEY=<your-api-key>  OR  act browser setup --api-key <key>"
+                "  OR  configure AWS credentials"
+            ),
+        )
+
+    def _check_session_dir(self) -> CheckResult:
+        """Check if session directory is writable."""
+        session_dir = get_session_dir()
+        try:
+            session_dir.mkdir(parents=True, exist_ok=True)
+            if os.access(session_dir, os.W_OK):
+                return CheckResult(name="Session directory writable", status="pass", message=str(session_dir))
+            return CheckResult(
+                name="Session directory writable",
+                status="fail",
+                message=f"Not writable: {session_dir}",
+                fix=f"Fix permissions: chmod u+w {session_dir}",
+            )
+        except OSError as e:
+            return CheckResult(
+                name="Session directory writable",
+                status="fail",
+                message=f"Cannot create: {session_dir} ({e})",
+                fix=f"Create directory manually: mkdir -p {session_dir}",
+            )
+
+    def _check_playwright(self) -> CheckResult:
+        """Check if Playwright Chromium is installed."""
+        try:
+            from playwright.sync_api import sync_playwright  # noqa: PLC0415
+
+            with sync_playwright() as p:
+                executable = p.chromium.executable_path
+                if executable and os.path.exists(executable):
+                    return CheckResult(
+                        name="Playwright Chromium installed",
+                        status="pass",
+                        message=f"Found at {executable}",
+                    )
+                return CheckResult(
+                    name="Playwright Chromium installed",
+                    status="info",
+                    message="Playwright installed but Chromium browser not found",
+                    fix="Run: python -m playwright install chromium",
+                )
+        except ImportError:
+            return CheckResult(
+                name="Playwright Chromium installed",
+                status="info",
+                message="Playwright not installed (optional)",
+                fix="pip install playwright && python -m playwright install chromium",
+            )
+        except Exception as e:
+            return CheckResult(
+                name="Playwright Chromium installed",
+                status="info",
+                message=f"Could not check Playwright: {e}",
+            )
+
+    def _check_orphaned_sessions(self) -> CheckResult:
+        """Check for orphaned browser sessions."""
+        try:
+            manager = SessionManager()
+            sessions = manager.list_sessions()
+            orphaned = [s for s in sessions if s.is_orphaned]
+            if orphaned:
+                ids = ", ".join(s.session_id for s in orphaned)
+                return CheckResult(
+                    name="No orphaned sessions",
+                    status="fail",
+                    message=f"{len(orphaned)} orphaned session(s): {ids}",
+                    fix="act browser session prune --ignore-ttl",
+                )
+            return CheckResult(name="No orphaned sessions", status="pass", message="No orphaned sessions found")
+        except Exception as e:
+            return CheckResult(name="No orphaned sessions", status="info", message=f"Could not check: {e}")
+
+    def _check_disk_usage(self) -> CheckResult:
+        """Check disk usage of CLI data directory."""
+        from nova_act.cli.browser.utils.disk_usage import check_disk_usage
+        from nova_act.cli.core.config import get_browser_cli_dir
+
+        cli_dir = get_browser_cli_dir()
+        if not cli_dir.exists():
+            return CheckResult(name="Disk usage", status="info", message="CLI data directory does not exist yet")
+        warning = check_disk_usage(cli_dir)
+        if warning:
+            return CheckResult(
+                name="Disk usage",
+                status="fail",
+                message=warning,
+                fix="act browser session prune --ignore-ttl",
+            )
+        return CheckResult(name="Disk usage", status="pass", message="CLI data directory within limits")
+
+    def run_checks(self) -> list[CheckResult]:
+        """Run all diagnostic checks."""
+        return [
+            self._check_chrome(),
+            self._check_auth(),
+            self._check_session_dir(),
+            self._check_playwright(),
+            self._check_orphaned_sessions(),
+            self._check_disk_usage(),
+        ]
+
+    def format_text(self, checks: list[CheckResult], log_path: Path) -> None:
+        """Format and output text results to terminal."""
+        out = get_cli_stdout()
+        passed = sum(1 for c in checks if c.status in ("pass", "info"))
+        failed = any(c.status == "fail" for c in checks)
+        total = len(checks)
+
+        for check in checks:
+            icon = _STATUS_ICONS.get(check.status or "", "?")
+            line = f"  {icon} {check.name}: {check.message}"
+            click.echo(line, file=out)
+            if check.status == "fail" and check.fix:
+                click.echo(f"    Fix: {check.fix}", file=out)
+
+        click.echo(f"\n  {passed}/{total} checks passed", file=out)
+        click.echo(f"  log_dir: {log_path.parent}", file=out)
+
+        if failed:
+            sys.exit(1)
+
+    def format_json(self, checks: list[CheckResult], log_path: Path) -> None:
+        """Format and output JSON results."""
+        out = get_cli_stdout()
+        passed = sum(1 for c in checks if c.status in ("pass", "info"))
+        failed = any(c.status == "fail" for c in checks)
+        total = len(checks)
+
+        result = {
+            "checks": [asdict(c) for c in checks],
+            "summary": {"passed": passed, "total": total},
+        }
+        if failed:
+            click.echo(
+                json.dumps(
+                    {"status": "error", "data": result, "log": str(log_path), "log_dir": str(log_path.parent)},
+                    default=str,
+                ),
+                file=out,
+            )
+            sys.exit(1)
+        json_success(result, log_path=str(log_path), log_dir=str(log_path.parent))
+
+    def run(self, verbose: bool) -> None:
+        """Full orchestration: log capture → checks → output."""
+        with capture_command_log(
+            "doctor",
+            session_id=None,
+            args={},
+            quiet=False,
+            verbose=verbose,
+        ) as log_path:
+            checks = self.run_checks()
+            if is_json_mode():
+                self.format_json(checks, log_path)
+            else:
+                self.format_text(checks, log_path)

--- a/src/nova_act/cli/browser/commands/setup/doctor.py
+++ b/src/nova_act/cli/browser/commands/setup/doctor.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Doctor command for diagnosing browser CLI environment health."""
+
+import click
+
+from nova_act.cli.browser.commands.setup.cli_doctor import CLIDoctor
+from nova_act.cli.browser.utils.decorators import setup_command_options
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+
+
+@click.command()
+@setup_command_options
+@handle_common_errors
+def doctor(verbose: bool) -> None:
+    """Run diagnostic checks on the browser CLI environment.
+
+    Checks Chrome installation, API key, session directory, and Playwright.
+
+    Examples:
+        act browser doctor
+        act browser doctor --json
+    """
+    CLIDoctor().run(verbose)

--- a/src/nova_act/cli/browser/commands/setup/qa_plan.py
+++ b/src/nova_act/cli/browser/commands/setup/qa_plan.py
@@ -1,0 +1,129 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""qa-plan command — compile Gherkin .feature files into CLI execution plans."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import click
+
+from nova_act.cli.browser.utils.decorators import json_option
+from nova_act.cli.core.output import echo_success, exit_with_error, get_cli_stdout
+
+
+@click.command(name="qa-plan")
+@click.argument("feature_file", type=click.Path(exists=True))
+@click.option(
+    "--plan-strategy",
+    type=click.Choice(["aggressive", "conservative"]),
+    default="aggressive",
+    show_default=True,
+    help="aggressive collapses sequential same-type steps; conservative maps 1:1",
+)
+@click.option("--tags", multiple=True, help="Filter scenarios by @tag (repeatable)")
+@click.option("--output", "-o", type=click.Path(), default=None, help="Save plan to file")
+@click.option("--dry-run", is_flag=True, help="Show plan summary without full JSON output")
+@json_option
+def qa_plan(feature_file: str, plan_strategy: str, tags: tuple[str, ...], output: str | None, dry_run: bool) -> None:
+    """Compile a Gherkin .feature file into a CLI execution plan.
+
+    Parses FEATURE_FILE and produces a JSON plan mapping Gherkin steps to
+    Nova Act CLI commands. The plan is consumed by an agent — qa-plan does
+    NOT execute anything.
+
+    Keyword mapping:
+      Given + URL → act browser goto
+      Given/When  → act browser execute
+      Then        → act browser verify
+
+    Examples:
+        act browser qa-plan tests/smoke.feature
+        act browser qa-plan tests/login.feature --plan-strategy conservative
+        act browser qa-plan tests/ --tags @smoke --tags @regression
+        act browser qa-plan tests/checkout.feature --output plan.json
+        act browser qa-plan tests/smoke.feature --dry-run
+    """
+    from nova_act.cli.browser.services.gherkin_compiler import compile_feature
+
+    path = Path(feature_file)
+
+    # Collect .feature files
+    if path.is_dir():
+        files = sorted(path.rglob("*.feature"))
+        if not files:
+            exit_with_error(
+                "No .feature files found",
+                f"No .feature files in {path}",
+                suggestions=["Check the path contains .feature files"],
+            )
+            return
+    else:
+        files = [path]
+
+    tag_list = list(tags) if tags else None
+    plans = []
+    for f in files:
+        plan = compile_feature(f, strategy=plan_strategy, tags=tag_list)
+        if plan.scenarios:
+            d = asdict(plan)
+            # Add computed property that asdict() doesn't serialize
+            for sc_dict, sc_obj in zip(d["scenarios"], plan.scenarios):
+                sc_dict["requires_human_auth"] = sc_obj.requires_human_auth
+            plans.append(d)
+
+    if not plans:
+        exit_with_error(
+            "No matching scenarios",
+            "No scenarios matched the given tag filters",
+            suggestions=["Check your --tags filter"],
+        )
+        return
+
+    result = plans[0] if len(plans) == 1 else {"plans": plans, "total_features": len(plans)}
+
+    if dry_run:
+        total_scenarios = sum(len(p.get("scenarios", [])) for p in (plans if isinstance(plans, list) else [result]))
+        total_steps = sum(
+            len(s.get("steps", []))
+            for p in (plans if isinstance(plans, list) else [result])
+            for s in p.get("scenarios", [])
+        )
+        echo_success(
+            "Plan compiled (dry-run)",
+            details={
+                "features": len(plans),
+                "scenarios": total_scenarios,
+                "steps": total_steps,
+                "strategy": plan_strategy,
+            },
+        )
+        return
+
+    serialized = json.dumps(result, indent=2)
+
+    if output:
+        Path(output).write_text(serialized, encoding="utf-8")
+        echo_success(
+            f"Plan saved to {output}",
+            details={
+                "features": len(plans),
+                "scenarios": sum(len(p.get("scenarios", [])) for p in plans),
+            },
+        )
+    else:
+        out = get_cli_stdout()
+        click.echo(serialized, file=out)

--- a/src/nova_act/cli/browser/commands/setup/setup.py
+++ b/src/nova_act/cli/browser/commands/setup/setup.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup command for storing API key in local config."""
+
+from __future__ import annotations
+
+import click
+
+from nova_act.cli.browser.utils.decorators import setup_command_options
+from nova_act.cli.browser.utils.error_handlers import handle_common_errors
+from nova_act.cli.core.config import (
+    BrowserCliConfig,
+    get_browser_cli_config_file,
+    read_config,
+    write_config,
+)
+from nova_act.cli.core.output import echo_success
+
+# Minimum reasonable API key length
+MIN_API_KEY_LENGTH = 10
+
+
+def _validate_api_key(key: str) -> None:
+    """Validate API key format. Raises click.ClickException on failure."""
+    if len(key.strip()) < MIN_API_KEY_LENGTH:
+        raise click.ClickException(f"Invalid API key format: key must be at least {MIN_API_KEY_LENGTH} characters.")
+
+
+@click.command()
+@click.option("--api-key", default=None, help="API key (non-interactive mode)")
+@click.option("--aws-profile", default=None, help="Default AWS profile name for AWS auth")
+@click.option("--aws-region", default=None, help="Default AWS region for AWS auth")
+@click.option("--workflow-name", default=None, help="Default workflow definition name for AWS auth")
+@click.option("--force", is_flag=True, default=False, help="Overwrite existing config without confirmation")
+@click.option("--clear", is_flag=True, default=False, help="Remove all stored config")
+@setup_command_options
+@handle_common_errors
+def setup(
+    api_key: str | None,
+    aws_profile: str | None,
+    aws_region: str | None,
+    workflow_name: str | None,
+    force: bool,
+    clear: bool,
+    verbose: bool,
+) -> None:
+    """Store authentication config for persistent use.
+
+    Stores settings in ~/.act_cli/browser/config.yaml so you don't need to pass
+    flags for every command.
+
+    Examples:
+        act browser setup --api-key <your-key>
+        act browser setup --aws-profile my-profile --aws-region us-west-2
+        act browser setup --workflow-name my-workflow
+        act browser setup --clear
+    """
+    if clear:
+        config_file = get_browser_cli_config_file()
+        if config_file.exists():
+            config_file.unlink()
+            echo_success("Config cleared", details={"config": str(config_file)})
+        else:
+            echo_success("No config file found — nothing to clear")
+        return
+
+    # If no flags provided, prompt for API key interactively
+    if api_key is None and aws_profile is None and aws_region is None and workflow_name is None:
+        api_key = click.prompt("Enter your Nova Act API key", hide_input=True)
+
+    if api_key is not None:
+        _validate_api_key(api_key)
+
+    # Read existing config and merge
+    config = read_config() if get_browser_cli_config_file().exists() else BrowserCliConfig()
+
+    if api_key is not None:
+        if config.api_key is not None and not force:
+            if not click.confirm("API key already configured. Overwrite?"):
+                raise click.Abort()
+        config.api_key = api_key.strip()
+    if aws_profile is not None:
+        config.aws_profile = aws_profile
+    if aws_region is not None:
+        config.aws_region = aws_region
+    if workflow_name is not None:
+        config.workflow_name = workflow_name
+
+    write_config(config)
+    stored = {k: v for k, v in vars(config).items() if v is not None}
+    echo_success("Config saved", details={"config": str(get_browser_cli_config_file()), **stored})

--- a/src/nova_act/cli/browser/config_schema.json
+++ b/src/nova_act/cli/browser/config_schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nova Act Browser Configuration",
+  "description": "Configuration schema for Nova Act CLI browser settings",
+  "type": "object",
+  "properties": {
+    "executable_path": {
+      "type": ["string", "null"],
+      "description": "Path to custom Chromium-based browser executable"
+    },
+    "headless": {
+      "type": "boolean",
+      "description": "Run browser in headless mode (no UI)",
+      "default": false
+    },
+    "profile": {
+      "type": ["string", "null"],
+      "description": "Path to browser profile directory for persistent sessions"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/nova_act/cli/browser/services/__init__.py
+++ b/src/nova_act/cli/browser/services/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser services module."""
+
+from nova_act.cli.browser.services.session.chrome_launcher import ChromeLauncher
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.locking import SessionLockManager
+from nova_act.cli.browser.services.session.manager import SessionManager
+from nova_act.cli.browser.services.session.models import (
+    BrowserOptions,
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.core.exceptions import SessionLockTimeout
+
+__all__ = [
+    "BrowserOptions",
+    "SessionInfo",
+    "SessionState",
+    "SessionLockTimeout",
+    "SessionLockManager",
+    "ChromeLauncher",
+    "ChromeTerminator",
+    "SessionPersistence",
+    "SessionManager",
+]

--- a/src/nova_act/cli/browser/services/action_results.py
+++ b/src/nova_act/cli/browser/services/action_results.py
@@ -1,0 +1,110 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Typed result dataclasses for BrowserActions methods."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import JsonValue
+
+
+@dataclass
+class NavigateResult:
+    arrived: bool
+    current_page: str
+    attempts: int
+    transition: str = ""
+
+
+@dataclass
+class ExploreResult:
+    page_summary: str
+    interactive_elements: list[str]
+    current_state: str
+    sections_explored: list[str]
+    exploration_depth: int
+
+
+@dataclass
+class SearchResult:
+    found: bool
+    location: str
+    summary: str
+    transition: str = ""
+
+
+@dataclass
+class VerifyResult:
+    passed: bool
+    actual: str
+    evidence: str
+    transition: str = ""
+
+
+@dataclass
+class WaitForResult:
+    met: bool
+    elapsed_seconds: float
+    polls: int
+    transition: str = ""
+
+
+@dataclass
+class DiffResult:
+    action: str
+    observe: str
+    before: JsonValue
+    after: JsonValue
+
+
+@dataclass
+class FillFormResult:
+    instruction: str
+    submitted: bool
+    outcome: str
+    transition: str = ""
+
+
+@dataclass
+class AskResult:
+    question: str
+    answer: JsonValue
+    url_changed: bool = False
+
+
+@dataclass
+class ExecuteResult:
+    transition: str = ""
+
+
+@dataclass
+class ScrollToResult:
+    reached: bool
+    target: str
+    attempts: int
+    transition: str = ""
+
+
+@dataclass
+class ClickResult:
+    clicked: str
+    transition: str
+
+
+@dataclass
+class TypeResult:
+    typed: str
+    target: str
+    transition: str = ""

--- a/src/nova_act/cli/browser/services/browser_actions/__init__.py
+++ b/src/nova_act/cli/browser/services/browser_actions/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""BrowserActions package — pure capability logic extracted from CLI commands.
+
+Takes a NovaAct instance and exposes every browser capability as a method.
+No Click, no output formatting, no logging — pure logic only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nova_act.cli.browser.services.browser_actions.exploration import ExplorationMixin
+from nova_act.cli.browser.services.browser_actions.inspection import (
+    ALL_PROPERTIES,
+    DEFAULT_EVALUATE_TIMEOUT_SECONDS,
+    InspectionMixin,
+    is_complex_result,
+    wrap_with_timeout,
+)
+from nova_act.cli.browser.services.browser_actions.interaction import InteractionMixin
+from nova_act.cli.browser.services.browser_actions.navigation import NavigationMixin
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+
+class BrowserActions(NavigationMixin, ExplorationMixin, InteractionMixin, InspectionMixin):
+    """Pure browser capability logic — no CLI, no output formatting, no logging."""
+
+    def __init__(self, nova_act: NovaAct) -> None:
+        self._nova_act = nova_act
+
+
+__all__ = [
+    "BrowserActions",
+    "ALL_PROPERTIES",
+    "DEFAULT_EVALUATE_TIMEOUT_SECONDS",
+    "is_complex_result",
+    "wrap_with_timeout",
+]

--- a/src/nova_act/cli/browser/services/browser_actions/exploration.py
+++ b/src/nova_act/cli/browser/services/browser_actions/exploration.py
@@ -1,0 +1,298 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exploration capabilities — explore and search."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, JsonValue
+
+from nova_act.cli.browser.services.action_results import ExploreResult, SearchResult
+from nova_act.cli.browser.services.browser_actions.utils import (
+    build_prompt_with_context,
+    build_prompt_with_focus,
+    get_page_context,
+    transition_tracker,
+)
+from nova_act.cli.browser.services.intent_resolution import (
+    SnapshotElement,
+    flatten_snapshot,
+)
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema models
+# ---------------------------------------------------------------------------
+class _ExploreSchema(BaseModel):
+    page_summary: str
+    interactive_elements: list[str]
+    current_state: str
+
+
+class _StepSchema(BaseModel):
+    findings: str
+    new_elements: list[str]
+
+
+class _SearchSchema(BaseModel):
+    found: bool
+    location: str
+    summary: str
+
+
+_INITIAL_PROMPT = (
+    "Describe what you see on this page: main content summary, "
+    "interactive elements (buttons, links, forms, inputs), and current page state. "
+    "Identify areas worth exploring further. Be concise."
+)
+_FOCUSED_EXPLORE_PROMPTS = [
+    (
+        "Scroll down and look for more content related to: {focus}. "
+        "Click into any relevant sections or links about {focus}."
+    ),
+    (
+        "Continue exploring — look for additional details, sub-pages, or hidden content about: {focus}. "
+        "Expand any collapsed sections."
+    ),
+    (
+        "Dig deeper — follow any remaining links or navigation related to: {focus}. "
+        "Check sidebars, footers, or secondary menus."
+    ),
+]
+_BROAD_EXPLORE_PROMPTS = [
+    (
+        "Scroll down to see more content on this page. "
+        "Click into the most important section or link you haven't explored yet."
+    ),
+    (
+        "Continue exploring — navigate to another major section of this site. "
+        "Check the main navigation menu for unvisited areas."
+    ),
+    ("Dig deeper — explore any remaining important sections, sub-pages, " "or content areas you haven't covered yet."),
+]
+_FOCUSED_OBSERVE_PROMPT = (
+    "Describe what you now see after exploring. "
+    "What new content or information about {focus} did you find? "
+    "What interactive elements are visible now?"
+)
+_BROAD_OBSERVE_PROMPT = (
+    "Describe what you now see after exploring. "
+    "What new content or information did you find? "
+    "What interactive elements are visible now?"
+)
+
+_SEARCH_PROMPT = (
+    "Find the following on this website: {query}. "
+    "Use site search, navigation menus, or page scanning — whatever works best. "
+    "Report whether you found it, where it is, and a brief summary."
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_focused_prompt(step: int, focus: str) -> str:
+    """Build the act() prompt for a focused exploration step."""
+    idx = min(step - 2, len(_FOCUSED_EXPLORE_PROMPTS) - 1)
+    return _FOCUSED_EXPLORE_PROMPTS[idx].format(focus=focus)
+
+
+def _build_broad_prompt(step: int) -> str:
+    """Build the act() prompt for a broad exploration step."""
+    idx = min(step - 2, len(_BROAD_EXPLORE_PROMPTS) - 1)
+    return _BROAD_EXPLORE_PROMPTS[idx]
+
+
+def _build_explore_prompt(step: int, focus: str | None) -> str:
+    """Build the act() prompt for an exploration step.
+
+    Delegates to _build_focused_prompt or _build_broad_prompt based on focus.
+    """
+    if focus:
+        return _build_focused_prompt(step, focus)
+    return _build_broad_prompt(step)
+
+
+def _build_observe_prompt(focus: str | None) -> str:
+    """Build the act_get() prompt for observing after exploration."""
+    if focus:
+        return _FOCUSED_OBSERVE_PROMPT.format(focus=focus)
+    return _BROAD_OBSERVE_PROMPT
+
+
+def _aggregate_findings(
+    initial_data: dict[str, JsonValue],
+    step_results: list[dict[str, JsonValue]],
+    depth: int,
+) -> ExploreResult:
+    """Merge initial overview with findings from exploration steps."""
+    raw_elements = initial_data.get("interactive_elements", [])
+    all_elements: list[str] = [str(e) for e in raw_elements] if isinstance(raw_elements, list) else []
+    summaries: list[str] = [str(initial_data.get("page_summary", ""))]
+
+    for step_data in step_results:
+        summaries.append(str(step_data.get("findings", "")))
+        new_elements = step_data.get("new_elements", [])
+        if isinstance(new_elements, list):
+            all_elements.extend(str(e) for e in new_elements)
+
+    unique_elements = list(dict.fromkeys(all_elements))
+    sections = [s for s in summaries if s]
+
+    return ExploreResult(
+        page_summary=" | ".join(s for s in summaries if s),
+        interactive_elements=unique_elements,
+        current_state=str(initial_data.get("current_state", "")),
+        sections_explored=sections,
+        exploration_depth=depth,
+    )
+
+
+class ExplorationMixin:
+    """Exploration and search capabilities for BrowserActions."""
+
+    _nova_act: NovaAct
+
+    def explore(
+        self, focus: str | None = None, depth: int = 3, timeout: int = 30, **method_args: object
+    ) -> ExploreResult:
+        """Multi-step structured exploration of the current page."""
+        initial_prompt = build_prompt_with_focus(_INITIAL_PROMPT, focus)
+
+        page_ctx = get_page_context(self._nova_act.page)
+        initial_result = self._nova_act.act_get(
+            build_prompt_with_context(initial_prompt, page_ctx),
+            schema=_ExploreSchema.model_json_schema(),
+            timeout=timeout,
+            **method_args,  # type: ignore[arg-type]
+        )
+        initial_data = initial_result.parsed_response if isinstance(initial_result.parsed_response, dict) else {}
+
+        step_results: list[dict[str, JsonValue]] = []
+        for step in range(2, depth + 1):
+            explore_prompt = _build_explore_prompt(step, focus)
+            page_ctx = get_page_context(self._nova_act.page)
+            self._nova_act.act(
+                build_prompt_with_context(explore_prompt, page_ctx),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+
+            observe_prompt = _build_observe_prompt(focus)
+            page_ctx = get_page_context(self._nova_act.page)
+            step_result = self._nova_act.act_get(
+                build_prompt_with_context(observe_prompt, page_ctx),
+                schema=_StepSchema.model_json_schema(),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            step_data = step_result.parsed_response if isinstance(step_result.parsed_response, dict) else {}
+            step_results.append(step_data)
+
+        return _aggregate_findings(initial_data, step_results, depth)
+
+    def _find_search_element(self) -> SnapshotElement | None:
+        """Find a search input element from the accessibility snapshot.
+
+        Looks for: searchbox (any), textbox with "search" in name, button with "search" in name.
+        Returns the best match by priority: searchbox > textbox > button.
+        """
+        try:
+            tree = self._nova_act.page.accessibility.snapshot()
+            elements = flatten_snapshot(tree)
+        except Exception:
+            return None
+
+        best: SnapshotElement | None = None
+        best_priority = 4  # lower is better
+        for elem in elements:
+            if elem.role == "searchbox":
+                return elem  # highest priority — return immediately
+            if elem.role == "textbox" and "search" in elem.name.lower() and best_priority > 2:
+                best, best_priority = elem, 2
+            elif elem.role == "button" and "search" in elem.name.lower() and best_priority > 3:
+                best, best_priority = elem, 3
+        return best
+
+    def _try_fast_search(self, query: str) -> SearchResult | None:
+        """Attempt fast-path search via snapshot element detection. Returns SearchResult on success, None on failure."""
+        try:
+            elem = self._find_search_element()
+            if elem is None:
+                return None
+
+            page = self._nova_act.page
+            with transition_tracker(page) as tracker:
+                if elem.role in ("searchbox", "textbox"):
+                    page.get_by_role(elem.role, name=elem.name).fill(query)  # type: ignore[arg-type]
+                    page.keyboard.press("Enter")
+                    return SearchResult(
+                        found=True,
+                        location="search results",
+                        summary=f"Searched for '{query}' via fast path.",
+                        transition=tracker.transition(f"Typed '{query}' into search and submitted."),
+                    )
+
+                if elem.role == "button":
+                    page.get_by_role("button", name=elem.name).click()
+                    page.wait_for_timeout(500)
+                    revealed = self._find_search_element()
+                    if revealed and revealed.role in ("searchbox", "textbox"):
+                        page.get_by_role(revealed.role, name=revealed.name).fill(query)  # type: ignore[arg-type]
+                        page.keyboard.press("Enter")
+                        return SearchResult(
+                            found=True,
+                            location="search results",
+                            summary=f"Searched for '{query}' via fast path (search icon).",
+                            transition=tracker.transition(f"Clicked search icon, typed '{query}', and submitted."),
+                        )
+                    return None
+
+        except Exception:
+            logger.debug("Fast search failed for '%s', falling back to AI", query)
+            return None
+        return None
+
+    def search(self, query: str, focus: str | None = None, timeout: int = 30, **method_args: object) -> SearchResult:
+        """Search the current website for content. Tries fast path first, falls back to AI."""
+        # --- Fast path: find search input via snapshot ---
+        fast_result = self._try_fast_search(query)
+        if fast_result is not None:
+            return fast_result
+
+        # --- Smart path: AI search ---
+        with transition_tracker(self._nova_act.page) as tracker:
+            prompt = build_prompt_with_focus(_SEARCH_PROMPT.format(query=query), focus)
+            result = self._nova_act.act_get(
+                prompt,
+                schema=_SearchSchema.model_json_schema(),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            data = result.parsed_response if isinstance(result.parsed_response, dict) else {}
+            return SearchResult(
+                found=bool(data.get("found", False)),
+                location=str(data.get("location", "")),
+                summary=str(data.get("summary", "")),
+                transition=tracker.transition(f"Searched for '{query}'."),
+            )

--- a/src/nova_act/cli/browser/services/browser_actions/inspection.py
+++ b/src/nova_act/cli/browser/services/browser_actions/inspection.py
@@ -1,0 +1,206 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inspection capabilities — extract, get_content, screenshot, query_dom, get_styles, evaluate_js, diff."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from nova_act.cli.browser.services.action_results import DiffResult
+from nova_act.cli.browser.utils.parsing import parse_json_schema
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Locator
+
+    from nova_act import NovaAct
+
+# ---------------------------------------------------------------------------
+# Pydantic schema models & constants
+# ---------------------------------------------------------------------------
+_DEFAULT_OBSERVE_PROMPT = "Describe what you observe on this page."
+
+
+class _ObserveSchema(BaseModel):
+    observation: str
+
+
+DEFAULT_EVALUATE_TIMEOUT_SECONDS = 30
+
+_GET_STYLES_JS = """
+(args) => {
+    const [selector, properties] = args;
+    const elements = document.querySelectorAll(selector);
+    if (elements.length === 0) return null;
+    return Array.from(elements).map(el => {
+        const computed = getComputedStyle(el);
+        if (properties.length > 0) {
+            const result = {};
+            for (const prop of properties) {
+                result[prop] = computed.getPropertyValue(prop);
+            }
+            return result;
+        }
+        const result = {};
+        for (let i = 0; i < computed.length; i++) {
+            const name = computed[i];
+            result[name] = computed.getPropertyValue(name);
+        }
+        return result;
+    });
+}
+"""
+
+ALL_PROPERTIES = ("tag", "text", "visible", "boundingBox")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def wrap_with_timeout(expression: str, timeout_seconds: int) -> str:
+    """Wrap a JS expression in Promise.race with a timeout."""
+    timeout_ms = timeout_seconds * 1000
+    escaped = expression.replace("\\", "\\\\").replace("`", "\\`").replace("$", "\\$")
+    return (
+        f"Promise.race(["
+        f"Promise.resolve().then(() => {{ return ({escaped}); }}),"
+        f"new Promise((_, reject) => setTimeout("
+        f"() => reject(new Error('Evaluation timed out after {timeout_seconds}s')), {timeout_ms}))"
+        f"])"
+    )
+
+
+def is_complex_result(result: object) -> bool:
+    return isinstance(result, (list, dict))
+
+
+def _get_element_properties(element: "Locator", props: tuple[str, ...]) -> dict[str, object]:
+    """Extract requested properties from a single element."""
+    result: dict[str, object] = {}
+    if "tag" in props:
+        result["tag"] = element.evaluate("el => el.tagName.toLowerCase()")
+    if "text" in props:
+        result["text"] = element.inner_text()
+    if "visible" in props:
+        result["visible"] = element.is_visible()
+    if "boundingBox" in props:
+        result["boundingBox"] = element.bounding_box()
+    return result
+
+
+class InspectionMixin:
+    """Inspection and extraction capabilities for BrowserActions."""
+
+    _nova_act: NovaAct
+
+    def extract(self, prompt: str, schema: str | None = None, timeout: int = 30, **method_args: object) -> object:
+        """Extract structured data from the current page. Returns parsed response."""
+        parsed_schema = parse_json_schema(schema)
+        result = self._nova_act.act_get(
+            prompt,
+            schema=parsed_schema,  # type: ignore[arg-type]
+            timeout=timeout,
+            **method_args,  # type: ignore[arg-type]
+        )
+        return result.parsed_response if result.parsed_response is not None else result.response
+
+    def get_content(self, output_format: str = "text") -> str:
+        """Get page content in specified format (text, html, markdown)."""
+        if output_format == "html":
+            return self._nova_act.page.content()
+        elif output_format == "markdown":
+            from markdownify import markdownify as md
+
+            return md(self._nova_act.page.content())
+        else:
+            return self._nova_act.page.inner_text("body")
+
+    def screenshot(self, full_page: bool = False, output_format: str = "png", quality: int = 80) -> bytes:
+        """Capture a screenshot. Returns raw bytes."""
+        from nova_act.cli.browser.utils.browser_config_cli import (
+            build_screenshot_kwargs,
+        )
+
+        screenshot_config = build_screenshot_kwargs(output_format, full_page, quality)
+        return self._nova_act.page.screenshot(**screenshot_config.to_kwargs())  # type: ignore[arg-type]
+
+    def query_dom(self, selector: str, properties: tuple[str, ...] = ALL_PROPERTIES) -> list[dict[str, object]]:
+        """Query page elements matching a CSS selector and return their properties."""
+        elements = self._nova_act.page.locator(selector).all()
+        return [_get_element_properties(el, properties) for el in elements]
+
+    def get_styles(self, selector: str, properties: tuple[str, ...] = ()) -> list[dict[str, object]]:
+        """Get computed CSS styles for elements matching a selector.
+
+        Raises if no elements found.
+        """
+        result = self._nova_act.page.evaluate(_GET_STYLES_JS, [selector, list(properties)])
+        if result is None:
+            raise ValueError(f"No elements found matching selector: {selector}")
+        return result  # type: ignore[no-any-return]
+
+    def evaluate_js(self, expression: str, timeout: int = DEFAULT_EVALUATE_TIMEOUT_SECONDS) -> object:
+        """Evaluate a JavaScript expression in the page context.
+
+        Raises on timeout (caller should handle).
+        """
+        wrapped = wrap_with_timeout(expression, timeout)
+        return self._nova_act.page.evaluate(wrapped)
+
+    def diff(
+        self,
+        action: str,
+        observe: str | None = None,
+        schema: str | None = None,
+        focus: str | None = None,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> DiffResult:
+        """Observe page state before and after an action using a single act_get call.
+
+        Combines observation and action into one inference call for 3x cost/latency reduction.
+        """
+        obs_prompt = observe or _DEFAULT_OBSERVE_PROMPT
+        focus_suffix = f" Focus on: {focus}." if focus else ""
+
+        combined_prompt = (
+            f"First, describe what you currently observe on the page ({obs_prompt}).{focus_suffix} "
+            f"Then perform this action: {action}. "
+            f"Then describe what you observe after the action ({obs_prompt}).{focus_suffix} "
+            f"Return your observations as a JSON object with 'before' and 'after' keys."
+        )
+
+        combined_schema = {
+            "type": "object",
+            "properties": {
+                "before": {"type": "object", "description": "Observation before the action"},
+                "after": {"type": "object", "description": "Observation after the action"},
+            },
+            "required": ["before", "after"],
+        }
+
+        result = self._nova_act.act_get(
+            combined_prompt,
+            schema=combined_schema,  # type: ignore[arg-type]
+            timeout=timeout,
+            **method_args,  # type: ignore[arg-type]
+        )
+        data = result.parsed_response if result.parsed_response is not None else {}
+        before = data.get("before", {}) if isinstance(data, dict) else {}
+        after = data.get("after", {}) if isinstance(data, dict) else {}
+
+        return DiffResult(action=action, observe=obs_prompt, before=before, after=after)

--- a/src/nova_act/cli/browser/services/browser_actions/interaction.py
+++ b/src/nova_act/cli/browser/services/browser_actions/interaction.py
@@ -1,0 +1,394 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interaction capabilities — execute, ask, fill_form, verify, wait_for."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+from urllib.parse import urldefrag
+
+from pydantic import BaseModel
+
+from nova_act.cli.browser.services.action_results import (
+    AskResult,
+    ClickResult,
+    ExecuteResult,
+    FillFormResult,
+    TypeResult,
+    VerifyResult,
+    WaitForResult,
+)
+from nova_act.cli.browser.services.browser_actions.utils import (
+    BOOL_SCHEMA,
+    build_prompt_with_context,
+    build_prompt_with_focus,
+    get_page_context,
+    transition_tracker,
+)
+from nova_act.cli.browser.services.intent_resolution import ResolutionPath, resolve
+from nova_act.cli.browser.utils.parsing import parse_json_schema
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema models
+# ---------------------------------------------------------------------------
+class _AskDefaultSchema(BaseModel):
+    answer: str
+
+
+class _FillFormSchema(BaseModel):
+    outcome: str
+
+
+class _VerifySchema(BaseModel):
+    passed: bool
+    actual: str
+    evidence: str
+
+
+class _ClickSchema(BaseModel):
+    clicked: bool
+
+
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+_ASK_PROMPT = (
+    "Answer the following question based on what is visible on the page. "
+    "You MAY scroll up or down to find the answer. "
+    "Do NOT click links, navigate to other pages, type, or submit forms. "
+    "Question: {question}"
+)
+
+_FILL_FORM_NO_SUBMIT = (
+    "Fill in the form on this page with the following information: {form_data}. " "Do NOT submit the form."
+)
+_FILL_FORM_SUBMIT = (
+    "Fill in the form on this page with the following information: {form_data}. " "Then submit the form."
+)
+
+_VERIFY_ASSERTION_PROMPT = (
+    "Determine if the following is true on this page: {assertion}. "
+    "You may scroll, expand sections, or interact with the page as needed to check. "
+    "Report: whether it passed (true/false), what you actually see, and your evidence."
+)
+
+_POLL_PROMPT = "Is the following condition currently met on this page: {condition}? Answer true or false."
+
+_CLICK_PROMPT = "Click on the following element: {target}."
+
+
+def _urls_differ_ignoring_fragment(url_before: str, url_after: str) -> bool:
+    """Return True if URLs differ ignoring fragment (anchor) portion."""
+    return urldefrag(url_before).url != urldefrag(url_after).url
+
+
+class InteractionMixin:
+    """Interaction capabilities for BrowserActions."""
+
+    _nova_act: NovaAct
+
+    def execute(self, prompt: str, timeout: int, **method_args: object) -> ExecuteResult:
+        """Execute a browser action via act(). Returns an ExecuteResult with transition."""
+        with transition_tracker(self._nova_act.page) as tracker:
+            page_ctx = get_page_context(self._nova_act.page)
+            self._nova_act.act(
+                build_prompt_with_context(prompt, page_ctx),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            return ExecuteResult(transition=tracker.transition(f"Executed: {prompt[:80]}"))
+
+    def _try_fast_click(self, target: str) -> ClickResult | None:
+        """Attempt fast-path click via intent resolution. Returns ClickResult on success, None on failure."""
+        try:
+            resolved = resolve(target, "click", self._nova_act.page)
+            if resolved.path != ResolutionPath.FAST:
+                return None
+            with transition_tracker(self._nova_act.page) as tracker:
+                if resolved.match_method == "selector":
+                    self._nova_act.page.locator(target).first.click()
+                elif resolved.element is not None:
+                    self._nova_act.page.get_by_role(
+                        resolved.element.role, name=resolved.element.name  # type: ignore[arg-type]
+                    ).click()
+                else:
+                    return None
+                return ClickResult(clicked=target, transition=tracker.transition(f"Clicked '{target}' via fast path."))
+        except Exception:
+            logger.debug("Fast click failed for '%s', falling back to AI", target)
+            return None
+
+    def click(self, target: str, focus: str | None = None, timeout: int = 30, **method_args: object) -> ClickResult:
+        """Click a specific element. Tries fast path (Playwright) first, falls back to AI."""
+        # --- Fast path: intent resolution → Playwright click ---
+        fast_result = self._try_fast_click(target)
+        if fast_result is not None:
+            return fast_result
+
+        # --- Smart path: AI act_get ---
+        with transition_tracker(self._nova_act.page) as tracker:
+            prompt = build_prompt_with_focus(_CLICK_PROMPT.format(target=target), focus)
+            result = self._nova_act.act_get(
+                prompt,
+                schema=_ClickSchema.model_json_schema(),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            data = result.parsed_response if result.parsed_response is not None else {}
+            return ClickResult(
+                clicked=target if (isinstance(data, dict) and data.get("clicked", False)) else "",
+                transition=tracker.transition(f"Clicked '{target}'."),
+            )
+
+    def ask(
+        self,
+        question: str,
+        schema: str | None = None,
+        focus: str | None = None,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> AskResult:
+        """Ask a read-only question about the current page.
+
+        Allows scrolling but validates that the page URL did not change
+        (navigation is forbidden).
+        """
+        url_before = self._nova_act.page.url
+        prompt = build_prompt_with_focus(_ASK_PROMPT.format(question=question), focus)
+        act_schema = parse_json_schema(schema) if schema else _AskDefaultSchema.model_json_schema()
+        result = self._nova_act.act_get(
+            prompt,
+            schema=act_schema,  # type: ignore[arg-type]
+            timeout=timeout,
+            **method_args,  # type: ignore[arg-type]
+        )
+        answer = result.parsed_response if result.parsed_response is not None else {}
+        answer_value = answer.get("answer", "") if isinstance(answer, dict) and not schema else answer
+
+        # Post-action URL validation: detect if the model navigated away
+        url_after = self._nova_act.page.url
+        url_changed = _urls_differ_ignoring_fragment(url_before, url_after)
+
+        return AskResult(question=question, answer=answer_value, url_changed=url_changed)
+
+    def _try_fast_fill(self, fields: dict[str, str]) -> tuple[dict[str, str], str]:
+        """Attempt fast-path fill for each field independently. Returns (failed_fields, transition)."""
+        failed: dict[str, str] = {}
+        filled_count = 0
+        with transition_tracker(self._nova_act.page) as tracker:
+            for key, value in fields.items():
+                try:
+                    resolved = resolve(key, "fill-form", self._nova_act.page)
+                    if resolved.path != ResolutionPath.FAST or resolved.element is None:
+                        failed[key] = value
+                        continue
+                    self._nova_act.page.get_by_role(
+                        resolved.element.role, name=resolved.element.name  # type: ignore[arg-type]
+                    ).fill(value)
+                    filled_count += 1
+                except Exception:
+                    logger.debug("Fast fill failed for field '%s', deferring to AI", key)
+                    failed[key] = value
+            return failed, tracker.transition(f"Filled {filled_count} field(s) via fast path.")
+
+    def fill_form(
+        self,
+        form_data: dict[str, str],
+        submit: bool = False,
+        focus: str | None = None,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> FillFormResult:
+        """Fill out a form on the current page using per-field resolution.
+
+        Tries Playwright fill for each field independently, then passes only
+        unmatched fields to AI as a reduced JSON.
+        """
+        import json as _json
+
+        instruction = _json.dumps(form_data)
+
+        # --- Fast path: per-field resolution ---
+        failed_fields, transition = self._try_fast_fill(form_data)
+
+        if not failed_fields:
+            # All fields filled via Playwright
+            if submit:
+                # Still need AI to submit since we don't know which button/action submits
+                with transition_tracker(self._nova_act.page) as tracker:
+                    self._nova_act.act_get(
+                        build_prompt_with_focus("Submit the form on this page.", focus),
+                        schema=_FillFormSchema.model_json_schema(),
+                        timeout=timeout,
+                        **method_args,  # type: ignore[arg-type]
+                    )
+                    transition = tracker.transition("Submitted the form.")
+            return FillFormResult(
+                instruction=instruction,
+                submitted=submit,
+                outcome="All fields filled via fast path.",
+                transition=transition,
+            )
+
+        # --- Smart path: AI fills only the failed fields ---
+        ai_data = _json.dumps(failed_fields)
+        template = _FILL_FORM_SUBMIT if submit else _FILL_FORM_NO_SUBMIT
+        with transition_tracker(self._nova_act.page) as tracker:
+            prompt = build_prompt_with_focus(template.format(form_data=ai_data), focus)
+            result = self._nova_act.act_get(
+                prompt,
+                schema=_FillFormSchema.model_json_schema(),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            data = result.parsed_response if result.parsed_response is not None else {}
+            fast_count = len(form_data) - len(failed_fields)
+            ai_outcome = str(data.get("outcome", "")) if isinstance(data, dict) else str(data)
+            outcome = f"{fast_count} field(s) filled via fast path. {ai_outcome}" if fast_count > 0 else ai_outcome
+            return FillFormResult(
+                instruction=instruction,
+                submitted=submit,
+                outcome=outcome,
+                transition=tracker.transition("Filled form fields via AI."),
+            )
+
+    def verify(
+        self, assertion: str, focus: str | None = None, timeout: int = 30, **method_args: object
+    ) -> VerifyResult:
+        """Visually assert a condition on the current page."""
+        with transition_tracker(self._nova_act.page) as tracker:
+            prompt = build_prompt_with_focus(_VERIFY_ASSERTION_PROMPT.format(assertion=assertion), focus)
+            page_ctx = get_page_context(self._nova_act.page)
+            result = self._nova_act.act_get(
+                build_prompt_with_context(prompt, page_ctx),
+                schema=_VerifySchema.model_json_schema(),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+            data = result.parsed_response if result.parsed_response is not None else {}
+            return VerifyResult(
+                passed=bool(data.get("passed", False)) if isinstance(data, dict) else False,
+                actual=str(data.get("actual", "")) if isinstance(data, dict) else str(data),
+                evidence=str(data.get("evidence", "")) if isinstance(data, dict) else "",
+                transition=tracker.transition(f"Verified: {assertion[:80]}"),
+            )
+
+    def wait_for(
+        self,
+        condition: str,
+        timeout: int = 30,
+        interval: int = 5,
+        focus: str | None = None,
+        per_call_timeout: int = 30,
+        **method_args: object,
+    ) -> WaitForResult:
+        """Poll until a condition is met on the current page."""
+        prompt = build_prompt_with_focus(_POLL_PROMPT.format(condition=condition), focus)
+        with transition_tracker(self._nova_act.page) as tracker:
+            start = time.monotonic()
+            polls = 0
+            met = False
+
+            while True:
+                elapsed = time.monotonic() - start
+                remaining = timeout - elapsed
+                if remaining <= 0:
+                    break
+
+                polls += 1
+                call_timeout = int(min(remaining, per_call_timeout))
+                try:
+                    result = self._nova_act.act_get(
+                        prompt,
+                        schema=BOOL_SCHEMA,
+                        timeout=call_timeout,
+                        **method_args,  # type: ignore[arg-type]
+                    )
+
+                    if result.parsed_response is True:
+                        met = True
+                        break
+                except RuntimeError as e:
+                    logger.debug("Wait-for poll %d failed for '%s': %s", polls, condition, e)
+                    break
+
+                remaining_after = timeout - (time.monotonic() - start)
+                if remaining_after <= 0:
+                    break
+                time.sleep(min(interval, remaining_after))
+
+            return WaitForResult(
+                met=met,
+                elapsed_seconds=round(time.monotonic() - start, 1),
+                polls=polls,
+                transition=tracker.transition(f"The condition '{condition}' was {'met' if met else 'not met'}."),
+            )
+
+    def type_text(
+        self,
+        text: str,
+        target: str | None = None,
+        append: bool = False,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> TypeResult:
+        """Type text into a target element or the currently focused element.
+
+        Fast path: resolve target via intent resolution → Playwright fill/type.
+        AI fallback: act() with natural language prompt.
+        """
+        # Fast path: type into focused element
+        if target is None:
+            try:
+                focused = self._nova_act.page.locator(":focus")
+                if focused.count() > 0:
+                    if append:
+                        focused.type(text)
+                    else:
+                        focused.fill(text)
+                    return TypeResult(
+                        typed=text, target="focused element", transition=f"Typed '{text}' into focused element"
+                    )
+            except Exception:
+                logger.debug("Fast-path type into focused element failed")
+
+        # Fast path: resolve target
+        if target:
+            try:
+                resolution = resolve(target, "fill-form", self._nova_act.page)
+                if resolution.path == ResolutionPath.FAST and resolution.element:
+                    locator = self._nova_act.page.get_by_role(
+                        resolution.element.role, name=resolution.element.name  # type: ignore[arg-type]
+                    )
+                    if append:
+                        locator.type(text)
+                    else:
+                        locator.fill(text)
+                    return TypeResult(typed=text, target=target, transition=f"Typed '{text}' into '{target}'")
+            except Exception:
+                logger.debug("Fast-path type into target '%s' failed, falling back to AI", target)
+
+        # AI fallback
+        target_desc = target or "the currently focused input field"
+        prompt = f"Type the following text into {target_desc}: {text}"
+        self._nova_act.act(prompt, timeout=timeout, **method_args)  # type: ignore[arg-type]
+        return TypeResult(typed=text, target=target_desc, transition=f"Typed '{text}' into '{target_desc}'")

--- a/src/nova_act/cli/browser/services/browser_actions/navigation.py
+++ b/src/nova_act/cli/browser/services/browser_actions/navigation.py
@@ -1,0 +1,178 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Navigation capabilities — goto and navigate with verification."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from nova_act.cli.browser.services.action_results import NavigateResult, ScrollToResult
+from nova_act.cli.browser.services.browser_actions.utils import (
+    BOOL_SCHEMA,
+    build_prompt_with_context,
+    build_prompt_with_focus,
+    get_page_context,
+    transition_tracker,
+)
+from nova_act.cli.browser.services.intent_resolution import ResolutionPath, resolve
+from nova_act.cli.browser.utils.timeout import temporary_navigation_timeout
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+_NAV_PROMPT = "{instruction}"
+_VERIFY_PROMPT = (
+    "I just asked the browser to: {instruction}. "
+    "Look at the current page and determine if the action was successful — "
+    "did the page change as expected? "
+    "Answer true if yes, false if not."
+)
+
+_SCROLL_PROMPT = (
+    "Scroll the page to find: {target}. " "Only scroll — do NOT click links, navigate, type, or submit forms."
+)
+_SCROLL_VERIFY_PROMPT = (
+    "Is the following content currently visible on the page: {target}? " "Answer true if yes, false if not."
+)
+
+
+class NavigationMixin:
+    """Navigation capabilities for BrowserActions."""
+
+    _nova_act: NovaAct
+
+    def goto(self, url: str, timeout: int | None = None) -> None:
+        """Navigate to a URL via raw Playwright go_to_url."""
+        with temporary_navigation_timeout(self._nova_act, timeout):
+            self._nova_act.go_to_url(url)
+
+    def navigate(
+        self,
+        instruction: str,
+        focus: str | None = None,
+        max_retries: int = 3,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> NavigateResult:
+        """Execute a natural-language navigation instruction with verification retry loop."""
+        nav_prompt = build_prompt_with_focus(_NAV_PROMPT.format(instruction=instruction), focus)
+        verify_prompt = build_prompt_with_focus(_VERIFY_PROMPT.format(instruction=instruction), focus)
+
+        with transition_tracker(self._nova_act.page) as tracker:
+            page_ctx = get_page_context(self._nova_act.page)
+            self._nova_act.act(
+                build_prompt_with_context(nav_prompt, page_ctx),
+                timeout=timeout,
+                **method_args,  # type: ignore[arg-type]
+            )
+
+            arrived = False
+            attempts = 0
+            for _ in range(1, max_retries + 1):
+                attempts += 1
+                page_ctx = get_page_context(self._nova_act.page)
+                result = self._nova_act.act_get(
+                    build_prompt_with_context(verify_prompt, page_ctx),
+                    schema=BOOL_SCHEMA,
+                    timeout=timeout,
+                    **method_args,  # type: ignore[arg-type]
+                )
+                if result.parsed_response is True:
+                    arrived = True
+                    break
+
+            return NavigateResult(
+                arrived=arrived,
+                current_page=self._nova_act.page.url,
+                attempts=attempts,
+                transition=tracker.transition(f"Navigation to '{instruction}' {'succeeded' if arrived else 'failed'}."),
+            )
+
+    def _try_fast_scroll(self, target: str) -> str | None:
+        """Attempt fast-path scroll via intent resolution. Returns transition string on success, None on failure."""
+        try:
+            resolved = resolve(target, "scroll-to", self._nova_act.page)
+            if resolved.path != ResolutionPath.FAST:
+                return None
+            with transition_tracker(self._nova_act.page) as tracker:
+                if resolved.match_method == "selector":
+                    self._nova_act.page.locator(target).first.scroll_into_view_if_needed()
+                elif resolved.element is not None:
+                    self._nova_act.page.get_by_role(
+                        resolved.element.role, name=resolved.element.name  # type: ignore[arg-type]
+                    ).scroll_into_view_if_needed()
+                else:
+                    return None
+                return tracker.transition(f"Scrolled to '{target}' via fast path.")
+        except Exception:
+            logger.debug("Fast scroll failed for '%s', falling back to AI loop", target)
+            return None
+
+    def scroll_to(
+        self,
+        target: str,
+        max_attempts: int = 5,
+        timeout: int = 30,
+        **method_args: object,
+    ) -> ScrollToResult:
+        """Scroll to target content. Tries fast path (Playwright) first, falls back to AI loop."""
+        # --- Fast path: intent resolution → Playwright scroll ---
+        fast_transition = self._try_fast_scroll(target)
+        if fast_transition is not None:
+            return ScrollToResult(reached=True, target=target, attempts=0, transition=fast_transition)
+
+        # --- Smart path: AI scroll + verify loop ---
+        scroll_prompt = _SCROLL_PROMPT.format(target=target)
+        verify_prompt = _SCROLL_VERIFY_PROMPT.format(target=target)
+
+        with transition_tracker(self._nova_act.page) as tracker:
+            reached = False
+            final_attempt = max_attempts
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    page_ctx = get_page_context(self._nova_act.page)
+                    self._nova_act.act(
+                        build_prompt_with_context(scroll_prompt, page_ctx),
+                        timeout=timeout,
+                        **method_args,  # type: ignore[arg-type]
+                    )
+
+                    page_ctx = get_page_context(self._nova_act.page)
+                    result = self._nova_act.act_get(
+                        build_prompt_with_context(verify_prompt, page_ctx),
+                        schema=BOOL_SCHEMA,
+                        timeout=timeout,
+                        **method_args,  # type: ignore[arg-type]
+                    )
+                    if result.parsed_response is True:
+                        reached = True
+                        final_attempt = attempt
+                        break
+                except RuntimeError as e:
+                    logger.debug("Scroll attempt %d failed for '%s': %s", attempt, target, e)
+                    final_attempt = attempt
+                    break
+
+            return ScrollToResult(
+                reached=reached,
+                target=target,
+                attempts=final_attempt,
+                transition=tracker.transition(f"Scroll to '{target}' {'reached' if reached else 'not found'}."),
+            )

--- a/src/nova_act/cli/browser/services/browser_actions/utils.py
+++ b/src/nova_act/cli/browser/services/browser_actions/utils.py
@@ -1,0 +1,246 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared utilities for composite browser commands."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from nova_act.cli.browser.services.intent_resolution.snapshot import (
+    SnapshotElement,
+    flatten_snapshot,
+)
+from nova_act.util.jsonschema import BOOL_SCHEMA
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+    from nova_act import NovaAct
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BOOL_SCHEMA",
+    "OBSERVE_PROMPT",
+    "ObserveSchema",
+    "TransitionTracker",
+    "build_prompt_with_focus",
+    "generate_fast_transition",
+    "generate_structured_transition",
+    "get_page_context",
+    "build_prompt_with_context",
+    "run_observe",
+    "transition_tracker",
+]
+
+_PAGE_CONTEXT_JS = """() => ({
+    scrollX: Math.round(window.scrollX),
+    scrollY: Math.round(window.scrollY),
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+    pageWidth: document.documentElement.scrollWidth,
+    pageHeight: document.documentElement.scrollHeight,
+    url: window.location.href,
+    title: document.title
+})"""
+
+
+def get_page_context(page: Page) -> str:
+    """Gather scroll position, viewport, and page dimensions via page.evaluate().
+
+    Returns a concise context string, or empty string on failure.
+    """
+    try:
+        info = page.evaluate(_PAGE_CONTEXT_JS)
+        scroll_y = info["scrollY"]
+        page_height = info["pageHeight"]
+        viewport_h = info["viewportHeight"]
+        pct = round(scroll_y / max(page_height - viewport_h, 1) * 100) if page_height > viewport_h else 0
+
+        return (
+            f"[Page context] URL: {info['url']} | Title: {info['title']} | "
+            f"Viewport: {info['viewportWidth']}x{viewport_h} | "
+            f"Scroll: {scroll_y}px / {page_height}px tall ({pct}% scrolled)"
+        )
+    except Exception:
+        return ""
+
+
+def build_prompt_with_context(prompt: str, page_context: str) -> str:
+    """Prepend page context to a prompt if available."""
+    if page_context:
+        return f"{page_context}\n{prompt}"
+    return prompt
+
+
+def build_prompt_with_focus(base_prompt: str, focus: str | None) -> str:
+    """Append focus instruction to a prompt if provided."""
+    if focus:
+        return f"{base_prompt} Focus specifically on: {focus}."
+    return base_prompt
+
+
+# ---------------------------------------------------------------------------
+# Fast-path transition generation from snapshot diffs
+# ---------------------------------------------------------------------------
+
+
+def generate_fast_transition(
+    before: list[SnapshotElement],
+    after: list[SnapshotElement],
+    action_description: str,
+) -> str:
+    """Generate a concise transition narrative from before/after snapshot diff.
+
+    Compares element lists by (role, name) pairs to detect additions, removals,
+    and value changes. Returns a human-readable summary.
+    """
+    before_map = {(e.role, e.name): e for e in before}
+    after_map = {(e.role, e.name): e for e in after}
+
+    before_keys = set(before_map)
+    after_keys = set(after_map)
+
+    added = after_keys - before_keys
+    removed = before_keys - after_keys
+    changed: list[str] = []
+    for key in before_keys & after_keys:
+        b, a = before_map[key], after_map[key]
+        if b.value != a.value:
+            changed.append(f"{key[0]} '{key[1]}' value changed")
+        if b.checked != a.checked:
+            changed.append(f"{key[0]} '{key[1]}' {'checked' if a.checked else 'unchecked'}")
+        if b.disabled != a.disabled:
+            changed.append(f"{key[0]} '{key[1]}' {'disabled' if a.disabled else 'enabled'}")
+
+    parts = [action_description]
+    if added:
+        names = [f"{r} '{n}'" for r, n in sorted(added)[:5]]
+        parts.append(f"New elements appeared: {', '.join(names)}")
+    if removed:
+        names = [f"{r} '{n}'" for r, n in sorted(removed)[:5]]
+        parts.append(f"Elements removed: {', '.join(names)}")
+    if changed:
+        parts.append(f"Changes: {', '.join(changed[:5])}")
+    if not added and not removed and not changed:
+        parts.append("No visible changes detected.")
+
+    return " ".join(parts)
+
+
+def generate_structured_transition(
+    before: list[SnapshotElement],
+    after: list[SnapshotElement],
+) -> dict[str, list[dict[str, object]]]:
+    """Generate structured transition dict from before/after snapshot diff.
+
+    Returns ``{appeared: [...], removed: [...], changed: [...]}``.
+    Each sub-list is capped at 10 entries.
+    """
+    before_map = {(e.role, e.name): e for e in before}
+    after_map = {(e.role, e.name): e for e in after}
+    before_keys, after_keys = set(before_map), set(after_map)
+
+    appeared: list[dict[str, object]] = [{"role": r, "name": n} for r, n in sorted(after_keys - before_keys)[:10]]
+    removed: list[dict[str, object]] = [{"role": r, "name": n} for r, n in sorted(before_keys - after_keys)[:10]]
+
+    changed: list[dict[str, object]] = []
+    for key in sorted(before_keys & after_keys):
+        b, a = before_map[key], after_map[key]
+        if b.value != a.value:
+            changed.append({"role": key[0], "name": key[1], "field": "value", "from": b.value, "to": a.value})
+        if b.checked != a.checked:
+            changed.append({"role": key[0], "name": key[1], "field": "checked", "from": b.checked, "to": a.checked})
+        if b.disabled != a.disabled:
+            changed.append({"role": key[0], "name": key[1], "field": "disabled", "from": b.disabled, "to": a.disabled})
+
+    return {"appeared": appeared, "removed": removed, "changed": changed[:10]}
+
+
+@dataclass
+class TransitionTracker:
+    """Captures before/after snapshots and generates transition narratives.
+
+    Usage::
+
+        tracker = TransitionTracker(page)
+        tracker.capture_before()
+        # ... perform action ...
+        transition = tracker.transition("Clicked the button")
+    """
+
+    page: Page
+    _before: list[SnapshotElement] = field(default_factory=list, init=False)
+
+    def capture_before(self) -> None:
+        """Capture the 'before' accessibility snapshot."""
+        self._before = flatten_snapshot(self.page.accessibility.snapshot())
+
+    def transition(self, description: str) -> str:
+        """Capture 'after' snapshot and return transition narrative."""
+        after = flatten_snapshot(self.page.accessibility.snapshot())
+        return generate_fast_transition(self._before, after, description)
+
+
+@contextmanager
+def transition_tracker(page: Page) -> Iterator[TransitionTracker]:
+    """Context manager that captures a before snapshot on entry.
+
+    Usage::
+
+        with transition_tracker(page) as tracker:
+            # ... perform action ...
+            result.transition = tracker.transition("Did something")
+    """
+    tracker = TransitionTracker(page)
+    tracker.capture_before()
+    yield tracker
+
+
+# ---------------------------------------------------------------------------
+# Observe — opt-in page layout description (separate act_get call)
+# ---------------------------------------------------------------------------
+
+OBSERVE_PROMPT = (
+    "Without scrolling or clicking anything, describe the current visual layout "
+    "of the page. Include: what content is visible, where key elements are "
+    "positioned, colors and styling of major elements, and the general state of the page."
+)
+
+
+class ObserveSchema(BaseModel):
+    layout: str
+
+
+def run_observe(nova_act: NovaAct) -> str:
+    """Fire a separate act_get() to describe the current page layout.
+
+    Returns the layout string, or empty string on failure.
+    """
+    try:
+        result = nova_act.act_get(OBSERVE_PROMPT, schema=ObserveSchema.model_json_schema())
+        resp = result.parsed_response
+        if isinstance(resp, dict):
+            layout = resp.get("layout", "")
+            return str(layout) if layout else ""
+        return ""
+    except Exception:
+        logger.debug("observe call failed", exc_info=True)
+        return ""

--- a/src/nova_act/cli/browser/services/browser_config.py
+++ b/src/nova_act/cli/browser/services/browser_config.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Centralized browser and CDP configuration constants."""
+
+import signal
+
+
+class DefaultBrowserConfig:
+    """Centralized configuration for browser and CDP settings.
+
+    This class consolidates all magic numbers and configuration constants
+    used across session management, Chrome launching, and CDP endpoint management.
+    """
+
+    # CDP Configuration
+    CDP_PORT_RANGE_START = 9222
+    CDP_PORT_RANGE_END = 9322
+    CDP_ENDPOINT_TIMEOUT_SECONDS = 15
+    CDP_ENDPOINT_POLL_INTERVAL_SECONDS = 0.5
+    CDP_VERSION_CHECK_TIMEOUT_SECONDS = 5
+    CDP_POLL_REQUEST_TIMEOUT_SECONDS = 1
+
+    # Browser Configuration
+    DEFAULT_WINDOW_SIZE = "1600,900"
+    CHROME_TERMINATION_GRACE_PERIOD_SECONDS = 2
+    CHROME_TERMINATION_SIGNAL = signal.SIGTERM
+    CHROME_FORCE_KILL_SIGNAL = signal.SIGKILL
+    BROWSER_VERSION_CHECK_TIMEOUT_SECONDS = 5
+    BROWSER_PROCESS_NAMES = ("chrome", "chromium", "msedge", "brave")
+
+    # Session Configuration
+    SESSION_LOCK_TIMEOUT_SECONDS = 30.0
+
+    # Session Guardrails
+    DEFAULT_MAX_ACTIVE_SESSIONS = 5
+    SESSION_STALE_TTL_HOURS = 24
+
+    # Act Execution
+    DEFAULT_ACT_TIMEOUT_SECONDS = 300

--- a/src/nova_act/cli/browser/services/console_capture.py
+++ b/src/nova_act/cli/browser/services/console_capture.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Console message capture service using Playwright page event listeners.
+
+Follows the EVENT-LISTENER PATTERN established by network_capture.py.
+Uses page.on('console') and page.on('pageerror') to capture browser console output.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.sync_api import ConsoleMessage, Error, Page
+
+DEFAULT_MAX_ENTRIES = 500
+
+
+@dataclass
+class ConsoleEntry:
+    """Single captured console message or page error."""
+
+    level: str  # log, warning, error, info, debug, trace, pageerror
+    text: str
+    timestamp: float
+    source_url: str | None = None
+    line_number: int | None = None
+    column_number: int | None = None
+    args: list[str] = field(default_factory=list)
+
+
+class ConsoleCaptureService:
+    """Captures console messages and page errors from a Playwright page.
+
+    Uses a ring buffer (deque with maxlen) to bound memory usage.
+    Mirrors NetworkCaptureService's attach/detach/get_entries/clear API.
+
+    Usage:
+        capture = ConsoleCaptureService()
+        capture.attach(page)
+        # ... browser activity ...
+        entries = capture.get_entries()
+        capture.detach(page)
+    """
+
+    def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES) -> None:
+        self._entries: deque[ConsoleEntry] = deque(maxlen=max_entries)
+        self._attached = False
+
+    @property
+    def is_attached(self) -> bool:
+        return self._attached
+
+    def attach(self, page: Page) -> None:
+        """Register console and pageerror listeners on page."""
+        if self._attached:
+            return
+        page.on("console", self._on_console)
+        page.on("pageerror", self._on_pageerror)
+        self._attached = True
+
+    def detach(self, page: Page) -> None:
+        """Remove listeners from page."""
+        if not self._attached:
+            return
+        page.remove_listener("console", self._on_console)
+        page.remove_listener("pageerror", self._on_pageerror)
+        self._attached = False
+
+    def get_entries(
+        self,
+        *,
+        level: str | None = None,
+        text_filter: str | None = None,
+        errors_only: bool = False,
+        limit: int | None = None,
+    ) -> list[ConsoleEntry]:
+        """Return filtered entries, most recent last.
+
+        Args:
+            level: Filter by console level (log, warning, error, info, debug, pageerror).
+            text_filter: Glob pattern to match against message text.
+            errors_only: Shortcut to filter to error + pageerror only.
+            limit: Max entries to return (from most recent).
+        """
+        result = list(self._entries)
+
+        if errors_only:
+            result = [e for e in result if e.level in ("error", "pageerror")]
+        elif level:
+            result = [e for e in result if e.level == level]
+        if text_filter:
+            result = [e for e in result if fnmatch.fnmatch(e.text, text_filter)]
+        if limit and limit > 0:
+            result = result[-limit:]
+
+        return result
+
+    def clear(self) -> None:
+        """Clear all captured entries."""
+        self._entries.clear()
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._entries)
+
+    def _on_console(self, msg: ConsoleMessage) -> None:
+        location = msg.location
+        entry = ConsoleEntry(
+            level=msg.type,
+            text=msg.text,
+            timestamp=time.time(),
+            source_url=location.get("url") if location else None,
+            line_number=location.get("lineNumber") if location else None,
+            column_number=location.get("columnNumber") if location else None,
+        )
+        self._entries.append(entry)
+
+    def _on_pageerror(self, error: Error) -> None:
+        entry = ConsoleEntry(
+            level="pageerror",
+            text=str(error),
+            timestamp=time.time(),
+        )
+        self._entries.append(entry)

--- a/src/nova_act/cli/browser/services/gherkin_compiler.py
+++ b/src/nova_act/cli/browser/services/gherkin_compiler.py
@@ -1,0 +1,279 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gherkin-to-CLI plan compiler — parses .feature files into executable command plans."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from gherkin.parser import Parser
+from gherkin.parser_types import GherkinDocument, Scenario, ScenarioEnvelope, Step
+from gherkin.token_scanner import TokenScanner
+
+# URL pattern for Given steps that should map to navigate
+_URL_PATTERN = re.compile(r"""['"]?(https?://\S+?)['"]?\s*$""")
+
+# Keywords that flag human auth requirement
+_AUTH_KEYWORDS = re.compile(
+    r"\b(log\s*in|sign\s*in|authenticate|mfa|captcha|two.factor|2fa|otp|password)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class PlanStep:
+    """A single compiled step in the execution plan."""
+
+    type: str  # navigate, action, assertion
+    cli: str
+    source_steps: list[str]
+    requires: str | None = None
+    note: str | None = None
+
+
+@dataclass
+class ScenarioPlan:
+    """Compiled plan for a single scenario."""
+
+    name: str
+    tags: list[str]
+    steps: list[PlanStep]
+
+    @property
+    def requires_human_auth(self) -> bool:
+        return any(s.requires == "human_auth" for s in self.steps)
+
+
+@dataclass
+class FeaturePlan:
+    """Compiled plan for an entire feature file."""
+
+    feature: str
+    source_file: str
+    plan_strategy: str
+    scenarios: list[ScenarioPlan] = field(default_factory=list)
+
+
+def _resolve_keyword(keyword_type: str, prev_keyword_type: str | None) -> str:
+    """Resolve And/But to the previous keyword type."""
+    if keyword_type == "Conjunction" and prev_keyword_type:
+        return prev_keyword_type
+    return keyword_type
+
+
+def _step_type(keyword_type: str) -> str:
+    """Map resolved Gherkin keyword type to plan step type."""
+    if keyword_type == "Outcome":
+        return "assertion"
+    return "action"
+
+
+def _detect_navigate(keyword_type: str, text: str) -> str | None:
+    """If this is a Given step with a URL, return the URL. Otherwise None."""
+    if keyword_type != "Context":
+        return None
+    m = _URL_PATTERN.search(text)
+    return m.group(1) if m else None
+
+
+def _detect_auth(text: str) -> str | None:
+    """Return 'human_auth' if step text contains auth-related keywords."""
+    return "human_auth" if _AUTH_KEYWORDS.search(text) else None
+
+
+def _build_cli(step_type: str, text: str, url: str | None = None) -> str:
+    """Build the CLI command string for a step."""
+    if url:
+        return f"act browser goto '{url}'"
+    if step_type == "assertion":
+        return f'act browser verify "{text}"'
+    return f'act browser execute "{text}"'
+
+
+def _compile_steps_conservative(resolved_steps: list[tuple[str, str, str]]) -> list[PlanStep]:
+    """Conservative strategy: 1:1 mapping from Gherkin steps to CLI commands."""
+    plan_steps: list[PlanStep] = []
+    for keyword_type, keyword_text, text in resolved_steps:
+        url = _detect_navigate(keyword_type, text)
+        stype = "navigate" if url else _step_type(keyword_type)
+        source = f"{keyword_text.strip()} {text}"
+        auth = _detect_auth(text)
+        plan_steps.append(
+            PlanStep(
+                type=stype,
+                cli=_build_cli(stype, text, url),
+                source_steps=[source],
+                requires=auth,
+                note="Login may require MFA or CAPTCHA" if auth else None,
+            )
+        )
+    return plan_steps
+
+
+def _group_consecutive_steps(resolved_steps: list[tuple[str, str, str]]) -> list[list[tuple[str, str, str]]]:
+    """Group consecutive steps of the same resolved type, splitting on navigate steps or type changes."""
+    groups: list[list[tuple[str, str, str]]] = []
+    current_group: list[tuple[str, str, str]] = [resolved_steps[0]]
+
+    for kw_type, kw_text, text in resolved_steps[1:]:
+        prev_type = current_group[0][0]
+        url = _detect_navigate(kw_type, text)
+        prev_url = _detect_navigate(prev_type, current_group[0][2])
+        if url or prev_url or kw_type != prev_type:
+            groups.append(current_group)
+            current_group = [(kw_type, kw_text, text)]
+        else:
+            current_group.append((kw_type, kw_text, text))
+    groups.append(current_group)
+    return groups
+
+
+def _compile_steps_aggressive(resolved_steps: list[tuple[str, str, str]]) -> list[PlanStep]:
+    """Aggressive strategy: collapse sequential same-type steps into single commands."""
+    if not resolved_steps:
+        return []
+
+    plan_steps: list[PlanStep] = []
+    groups = _group_consecutive_steps(resolved_steps)
+
+    for group in groups:
+        first_kw_type, _, first_text = group[0]
+        url = _detect_navigate(first_kw_type, first_text)
+        stype = "navigate" if url else _step_type(first_kw_type)
+        sources = [f"{kw.strip()} {t}" for _, kw, t in group]
+
+        if len(group) == 1:
+            combined_text = first_text
+        else:
+            # Collapse texts with commas + "and"
+            texts = [t for _, _, t in group]
+            combined_text = ", ".join(texts[:-1]) + ", and " + texts[-1] if len(texts) > 2 else " and ".join(texts)
+
+        auth = _detect_auth(combined_text)
+        plan_steps.append(
+            PlanStep(
+                type=stype,
+                cli=_build_cli(stype, combined_text, url),
+                source_steps=sources,
+                requires=auth,
+                note="Login may require MFA or CAPTCHA" if auth else None,
+            )
+        )
+    return plan_steps
+
+
+def _expand_outline(scenario: Scenario) -> list[Scenario]:
+    """Expand a Scenario Outline into concrete scenarios from Examples table."""
+    examples_list = scenario.get("examples", [])
+    if not examples_list:
+        return [scenario]
+
+    template_steps = scenario.get("steps", [])
+    expanded: list[Scenario] = []
+
+    for examples in examples_list:
+        header = examples.get("tableHeader")
+        columns = [c["value"] for c in header["cells"]] if header else []
+        rows = examples.get("tableBody", [])
+
+        for row in rows:
+            values = [c["value"] for c in row.get("cells", [])]
+            param_map = dict(zip(columns, values))
+
+            # Substitute <param> in step text and scenario name
+            name = scenario.get("name", "")
+            for k, v in param_map.items():
+                name = name.replace(f"<{k}>", v)
+
+            concrete_steps: list[Step] = []
+            for step in template_steps:
+                new_text = step["text"]
+                for k, v in param_map.items():
+                    new_text = new_text.replace(f"<{k}>", v)
+                concrete_steps.append({**step, "text": new_text})
+
+            expanded.append(
+                {
+                    **scenario,
+                    "name": name,
+                    "steps": concrete_steps,
+                    "examples": [],
+                    "keyword": "Scenario",
+                }
+            )
+    return expanded
+
+
+def compile_feature(
+    feature_path: str | Path, strategy: str = "aggressive", tags: list[str] | None = None
+) -> FeaturePlan:
+    """Compile a .feature file into an execution plan.
+
+    Args:
+        feature_path: Path to the .feature file.
+        strategy: 'aggressive' (collapse steps) or 'conservative' (1:1 mapping).
+        tags: Optional list of tags to filter scenarios (e.g. ['@smoke']).
+
+    Returns:
+        FeaturePlan with compiled scenarios.
+    """
+    path = Path(feature_path)
+    parser = Parser()
+    gherkin_doc: GherkinDocument = parser.parse(TokenScanner(path.read_text()))
+    feature = gherkin_doc.get("feature")
+    if not feature:
+        return FeaturePlan(feature="", source_file=str(path), plan_strategy=strategy)
+
+    plan = FeaturePlan(
+        feature=feature["name"],
+        source_file=str(path),
+        plan_strategy=strategy,
+    )
+
+    compile_fn = _compile_steps_aggressive if strategy == "aggressive" else _compile_steps_conservative
+
+    for child in feature.get("children", []):
+        scenario = cast(ScenarioEnvelope, child).get("scenario")
+        if not scenario:
+            continue
+
+        # Expand Scenario Outline
+        concrete_scenarios = _expand_outline(scenario) if scenario.get("examples") else [scenario]
+
+        for sc in concrete_scenarios:
+            sc_tags = [t["name"] for t in sc.get("tags", [])]
+            # Inherit feature-level tags
+            feature_tags = [t["name"] for t in feature.get("tags", [])]
+            all_tags = list(set(feature_tags + sc_tags))
+
+            # Tag filtering
+            if tags and not any(t in all_tags for t in tags):
+                continue
+
+            # Resolve And/But keywords
+            resolved: list[tuple[str, str, str]] = []
+            prev_kw_type: str | None = None
+            for step in sc.get("steps", []):
+                kw_type = _resolve_keyword(step["keywordType"], prev_kw_type)
+                if kw_type != "Conjunction":
+                    prev_kw_type = kw_type
+                resolved.append((kw_type, step["keyword"], step["text"]))
+
+            steps = compile_fn(resolved)
+            plan.scenarios.append(ScenarioPlan(name=sc["name"], tags=all_tags, steps=steps))
+
+    return plan

--- a/src/nova_act/cli/browser/services/intent_resolution/__init__.py
+++ b/src/nova_act/cli/browser/services/intent_resolution/__init__.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Intent resolution module — routes agent intent to fast (Playwright) or smart (AI) path."""
+
+from nova_act.cli.browser.services.intent_resolution.matching import (
+    FormatMatch,
+    MatchResult,
+    detect_format,
+    exact_match,
+    token_set_match,
+)
+from nova_act.cli.browser.services.intent_resolution.resolver import (
+    ResolutionPath,
+    ResolvedTarget,
+    resolve,
+)
+from nova_act.cli.browser.services.intent_resolution.snapshot import (
+    SnapshotElement,
+    flatten_snapshot,
+)
+
+__all__ = [
+    "FormatMatch",
+    "MatchResult",
+    "ResolvedTarget",
+    "ResolutionPath",
+    "SnapshotElement",
+    "detect_format",
+    "exact_match",
+    "flatten_snapshot",
+    "resolve",
+    "token_set_match",
+]

--- a/src/nova_act/cli/browser/services/intent_resolution/matching.py
+++ b/src/nova_act/cli/browser/services/intent_resolution/matching.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""3-tier matching: format detection, exact match, token set ratio."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from rapidfuzz import fuzz
+
+from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement
+
+# Tier 1 patterns
+_HTML_TAGS = (
+    r"a|abbr|address|article|aside|audio|b|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|"
+    r"dd|del|details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|"
+    r"hgroup|hr|html|i|iframe|img|input|ins|kbd|label|legend|li|link|main|map|mark|menu|meta|meter|nav|"
+    r"noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|"
+    r"search|section|select|slot|small|source|span|strong|style|sub|summary|sup|table|tbody|td|template|"
+    r"textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|video|wbr"
+)
+_CSS_SELECTOR_RE = re.compile(rf"^[#.\[]|^[a-z]+[\[.#:]|^(?:{_HTML_TAGS})$", re.IGNORECASE)
+_SNAPSHOT_REF_RE = re.compile(r"^e\d+$", re.IGNORECASE)
+
+FUZZY_SCORE_THRESHOLD = 85
+FUZZY_GAP_THRESHOLD = 15
+
+
+@dataclass
+class FormatMatch:
+    """Result of Tier 1 format detection."""
+
+    kind: str  # "css_selector" or "snapshot_ref"
+    value: str
+
+
+@dataclass
+class MatchResult:
+    """Result of Tier 3 token set ratio matching."""
+
+    element: SnapshotElement | None
+    score: float
+    confident: bool
+
+
+def detect_format(target: str) -> FormatMatch | None:
+    """Tier 1: Detect if target is a CSS selector or snapshot ref."""
+    target = target.strip()
+    if _SNAPSHOT_REF_RE.match(target):
+        return FormatMatch(kind="snapshot_ref", value=target)
+    if _CSS_SELECTOR_RE.match(target):
+        return FormatMatch(kind="css_selector", value=target)
+    return None
+
+
+def exact_match(target: str, elements: list[SnapshotElement]) -> SnapshotElement | None:
+    """Tier 2: Case-insensitive exact name match. Returns None if 0 or 2+ matches."""
+    target_lower = target.strip().lower()
+    matches = [e for e in elements if e.name and e.name.lower() == target_lower]
+    return matches[0] if len(matches) == 1 else None
+
+
+def token_set_match(target: str, elements: list[SnapshotElement]) -> MatchResult:
+    """Tier 3: Fuzzy match via rapidfuzz token_set_ratio.
+
+    Confident if best score >= FUZZY_SCORE_THRESHOLD AND gap to second-best >= FUZZY_GAP_THRESHOLD.
+    """
+    named = [e for e in elements if e.name]
+    if not named:
+        return MatchResult(element=None, score=0.0, confident=False)
+
+    scored = [(e, fuzz.token_set_ratio(target, e.name)) for e in named]
+    scored.sort(key=lambda x: x[1], reverse=True)
+
+    best_elem, best_score = scored[0]
+    second_score = scored[1][1] if len(scored) > 1 else 0.0
+    gap = best_score - second_score
+
+    if best_score >= FUZZY_SCORE_THRESHOLD and gap >= FUZZY_GAP_THRESHOLD:
+        return MatchResult(element=best_elem, score=best_score, confident=True)
+
+    return MatchResult(
+        element=best_elem if best_score >= FUZZY_SCORE_THRESHOLD else None, score=best_score, confident=False
+    )

--- a/src/nova_act/cli/browser/services/intent_resolution/resolver.py
+++ b/src/nova_act/cli/browser/services/intent_resolution/resolver.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Intent resolver: routes agent intent to fast (Playwright) or smart (AI) path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from nova_act.cli.browser.services.intent_resolution.matching import (
+    FUZZY_SCORE_THRESHOLD,
+    detect_format,
+    exact_match,
+    token_set_match,
+)
+from nova_act.cli.browser.services.intent_resolution.snapshot import (
+    SnapshotElement,
+    flatten_snapshot,
+)
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+
+class ResolutionPath(Enum):
+    FAST = "fast"
+    SMART = "smart"
+
+
+@dataclass
+class ResolvedTarget:
+    """Result of intent resolution."""
+
+    path: ResolutionPath
+    element: SnapshotElement | None = None
+    confidence: float = 0.0
+    match_method: str = ""
+
+
+# Role filters per command type
+CLICKABLE_ROLES = frozenset({"button", "link", "menuitem", "tab", "checkbox", "radio", "option", "switch", "treeitem"})
+FILLABLE_ROLES = frozenset({"textbox", "searchbox", "combobox", "spinbutton", "textarea"})
+SEARCH_ROLES = frozenset({"searchbox", "textbox", "button"})
+HEADING_LANDMARK_ROLES = frozenset(
+    {"heading", "region", "navigation", "contentinfo", "banner", "main", "complementary"}
+)
+
+HEADING_LANDMARK_BONUS = 5
+
+
+def _filter_by_command(elements: list[SnapshotElement], command_type: str) -> list[SnapshotElement]:
+    """Filter elements by roles relevant to the command type."""
+    if command_type == "click":
+        return [e for e in elements if e.role in CLICKABLE_ROLES]
+    if command_type == "fill-form":
+        return [e for e in elements if e.role in FILLABLE_ROLES]
+    if command_type == "search":
+        return [e for e in elements if e.role in SEARCH_ROLES or "search" in (e.name or "").lower()]
+    # scroll-to: all elements (bonus applied in matching)
+    return elements
+
+
+def resolve(target: str, command_type: str, page: "Page") -> ResolvedTarget:
+    """Resolve agent intent to a fast or smart path.
+
+    Args:
+        target: Natural language target, CSS selector, or snapshot ref.
+        command_type: One of "click", "fill-form", "scroll-to", "search".
+        page: Playwright Page for accessibility snapshot.
+
+    Returns:
+        ResolvedTarget indicating which path to take.
+    """
+    # Tier 1: Format detection (no snapshot needed)
+    fmt = detect_format(target)
+    if fmt:
+        if fmt.kind == "snapshot_ref":
+            # Need snapshot to look up the ref
+            tree = page.accessibility.snapshot()
+            elements = flatten_snapshot(tree)
+            for elem in elements:
+                if elem.ref.lower() == fmt.value.lower():
+                    return ResolvedTarget(path=ResolutionPath.FAST, element=elem, confidence=100.0, match_method="ref")
+            return ResolvedTarget(path=ResolutionPath.SMART, match_method="ref_not_found")
+        # CSS selector — fast path directly
+        return ResolvedTarget(path=ResolutionPath.FAST, confidence=100.0, match_method="selector")
+
+    # Tier 2 & 3: Need snapshot
+    tree = page.accessibility.snapshot()
+    elements = flatten_snapshot(tree)
+    filtered = _filter_by_command(elements, command_type)
+
+    # Tier 2: Exact match
+    exact = exact_match(target, filtered)
+    if exact:
+        return ResolvedTarget(path=ResolutionPath.FAST, element=exact, confidence=100.0, match_method="exact")
+
+    # Tier 3: Token set ratio
+    result = token_set_match(target, filtered)
+
+    # Apply heading/landmark bonus for scroll-to
+    if command_type == "scroll-to" and result.element and not result.confident:
+        if result.element.role in HEADING_LANDMARK_ROLES:
+            boosted = result.score + HEADING_LANDMARK_BONUS
+            if boosted >= FUZZY_SCORE_THRESHOLD:
+                # Re-check with bonus — need to verify gap still holds
+                result_confident = result.score >= (FUZZY_SCORE_THRESHOLD - HEADING_LANDMARK_BONUS)
+                if result_confident:
+                    return ResolvedTarget(
+                        path=ResolutionPath.FAST,
+                        element=result.element,
+                        confidence=boosted,
+                        match_method="token_set_ratio_boosted",
+                    )
+
+    if result.confident and result.element:
+        return ResolvedTarget(
+            path=ResolutionPath.FAST, element=result.element, confidence=result.score, match_method="token_set_ratio"
+        )
+
+    return ResolvedTarget(path=ResolutionPath.SMART, match_method="no_match")

--- a/src/nova_act/cli/browser/services/intent_resolution/snapshot.py
+++ b/src/nova_act/cli/browser/services/intent_resolution/snapshot.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Accessibility snapshot flattening and element representation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SnapshotElement:
+    """A flattened accessibility tree element with sequential ref."""
+
+    ref: str
+    role: str
+    name: str
+    value: str = ""
+    disabled: bool = False
+    checked: bool = False
+
+
+def flatten_snapshot(tree: dict[str, object] | None) -> list[SnapshotElement]:
+    """Flatten a Playwright accessibility snapshot tree into sequential elements.
+
+    Performs depth-first traversal, assigning refs e1, e2, ... to each node.
+    """
+    if not tree:
+        return []
+
+    elements: list[SnapshotElement] = []
+    counter = 0
+    stack: list[dict[str, object]] = [tree]
+
+    while stack:
+        node = stack.pop()
+        counter += 1
+        elements.append(
+            SnapshotElement(
+                ref=f"e{counter}",
+                role=str(node.get("role", "")),
+                name=str(node.get("name", "")),
+                value=str(node.get("value", "")),
+                disabled=bool(node.get("disabled", False)),
+                checked=bool(node.get("checked", False)),
+            )
+        )
+        # Push children in reverse so left children are processed first
+        children = node.get("children", [])
+        if isinstance(children, list):
+            for child in reversed(children):
+                if isinstance(child, dict):
+                    stack.append(child)
+
+    return elements

--- a/src/nova_act/cli/browser/services/network_capture.py
+++ b/src/nova_act/cli/browser/services/network_capture.py
@@ -1,0 +1,201 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Network traffic capture service using Playwright page event listeners.
+
+Establishes the EVENT-LISTENER PATTERN for page-level capture services.
+Console capture (Phase 2b) reuses this same pattern.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page, Request, Response
+
+DEFAULT_MAX_ENTRIES = 500
+
+
+@dataclass
+class NetworkEntry:
+    """Single captured network request/response pair."""
+
+    url: str
+    method: str
+    resource_type: str
+    timestamp: float
+    status: int | None = None
+    request_headers: dict[str, str] = field(default_factory=dict)
+    response_headers: dict[str, str] = field(default_factory=dict)
+    duration_ms: float | None = None
+    size: int | None = None
+    failed: bool = False
+    failure_text: str | None = None
+
+
+class NetworkCaptureService:
+    """Captures network traffic from a Playwright page via event listeners.
+
+    Uses a ring buffer (deque with maxlen) to bound memory usage.
+    Designed as a clean template for other event-listener capture services.
+
+    Usage:
+        capture = NetworkCaptureService()
+        capture.attach(page)
+        # ... browser activity ...
+        entries = capture.get_entries()
+        capture.detach(page)
+    """
+
+    def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES) -> None:
+        self._entries: deque[NetworkEntry] = deque(maxlen=max_entries)
+        self._entry_index: dict[str, NetworkEntry] = {}  # request_key -> entry for O(1) lookup
+        self._pending: dict[str, float] = {}  # request_key -> start_time
+        self._attached = False
+
+    @property
+    def is_attached(self) -> bool:
+        return self._attached
+
+    def attach(self, page: Page) -> None:
+        """Register request/response/requestfailed listeners on page."""
+        if self._attached:
+            return
+        page.on("request", self._on_request)
+        page.on("response", self._on_response)
+        page.on("requestfailed", self._on_request_failed)
+        self._attached = True
+
+    def detach(self, page: Page) -> None:
+        """Remove listeners from page."""
+        if not self._attached:
+            return
+        page.remove_listener("request", self._on_request)
+        page.remove_listener("response", self._on_response)
+        page.remove_listener("requestfailed", self._on_request_failed)
+        self._attached = False
+
+    def get_entries(
+        self,
+        *,
+        url_filter: str | None = None,
+        method: str | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> list[NetworkEntry]:
+        """Return filtered entries, most recent last.
+
+        Args:
+            url_filter: Glob pattern to match against URL (e.g. "*api*").
+            method: HTTP method filter (e.g. "GET", "POST").
+            status: Status filter — exact code ("200"), range ("4xx", "5xx"),
+                    or comparison (">=400").
+            limit: Max entries to return (from most recent).
+        """
+        result = list(self._entries)
+
+        if url_filter:
+            result = [e for e in result if fnmatch.fnmatch(e.url, url_filter)]
+        if method:
+            upper = method.upper()
+            result = [e for e in result if e.method == upper]
+        if status:
+            result = [e for e in result if _matches_status(e.status, status)]
+        if limit and limit > 0:
+            result = result[-limit:]
+
+        return result
+
+    def clear(self) -> None:
+        """Clear all captured entries and pending requests."""
+        self._entries.clear()
+        self._entry_index.clear()
+        self._pending.clear()
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._entries)
+
+    def _on_request(self, request: Request) -> None:
+        key = _request_key(request)
+        self._pending[key] = time.monotonic()
+        entry = NetworkEntry(
+            url=request.url,
+            method=request.method,
+            resource_type=request.resource_type,
+            timestamp=time.time(),
+            request_headers=dict(request.headers),
+        )
+        self._entries.append(entry)
+        self._entry_index[key] = entry
+
+    def _on_response(self, response: Response) -> None:
+        request = response.request
+        key = _request_key(request)
+        start = self._pending.pop(key, None)
+        duration = (time.monotonic() - start) * 1000 if start is not None else None
+
+        entry = self._entry_index.pop(key, None)
+        if entry is not None:
+            entry.status = response.status
+            entry.response_headers = dict(response.headers)
+            entry.duration_ms = round(duration, 1) if duration is not None else None
+            content_length = response.headers.get("content-length")
+            if content_length:
+                try:
+                    entry.size = int(content_length)
+                except ValueError:
+                    pass
+
+    def _on_request_failed(self, request: Request) -> None:
+        key = _request_key(request)
+        self._pending.pop(key, None)
+
+        entry = self._entry_index.pop(key, None)
+        if entry is not None:
+            entry.failed = True
+            entry.failure_text = request.failure
+
+
+def _request_key(request: Request) -> str:
+    """Unique key for matching request to response."""
+    return f"{request.method}:{request.url}:{id(request)}"
+
+
+def _matches_status(actual: int | None, pattern: str) -> bool:
+    """Check if a status code matches a filter pattern.
+
+    Supports: exact ("200"), range ("4xx", "5xx"), comparison (">=400").
+    """
+    if actual is None:
+        return False
+    if pattern.endswith("xx"):
+        try:
+            prefix = int(pattern[0])
+            return actual // 100 == prefix
+        except (ValueError, IndexError):
+            return False
+    if pattern.startswith(">="):
+        try:
+            return actual >= int(pattern[2:])
+        except ValueError:
+            return False
+    try:
+        return actual == int(pattern)
+    except ValueError:
+        return False

--- a/src/nova_act/cli/browser/services/performance_collector.py
+++ b/src/nova_act/cli/browser/services/performance_collector.py
@@ -1,0 +1,222 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Performance metrics collection via browser Performance API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+from typing_extensions import NotRequired
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+
+class NavigationTiming(TypedDict, total=False):
+    requestStart: float
+    responseStart: float
+    domInteractive: float
+    domComplete: float
+    loadEventEnd: float
+
+
+class ResourceTiming(TypedDict, total=False):
+    name: str
+    duration: float
+    transferSize: int
+
+
+class PaintTiming(TypedDict):
+    name: str
+    startTime: float
+
+
+class MemoryInfo(TypedDict):
+    usedJSHeapSize: int
+    totalJSHeapSize: int
+    jsHeapSizeLimit: int
+
+
+class VitalsInfo(TypedDict):
+    lcp: float | None
+    cls: float
+
+
+class PerfData(TypedDict):
+    navigation: NavigationTiming | None
+    resources: list[ResourceTiming]
+    paint: list[PaintTiming]
+    memory: MemoryInfo | None
+    vitals: NotRequired[VitalsInfo]
+
+
+# JavaScript to collect Navigation Timing, Resource Timing, Paint Timing, and Memory
+PERF_COLLECT_JS = """
+() => {
+    const nav = performance.getEntriesByType('navigation')[0];
+    const resources = performance.getEntriesByType('resource');
+    const paint = performance.getEntriesByType('paint');
+    const memory = performance.memory ? {
+        usedJSHeapSize: performance.memory.usedJSHeapSize,
+        totalJSHeapSize: performance.memory.totalJSHeapSize,
+        jsHeapSizeLimit: performance.memory.jsHeapSizeLimit,
+    } : null;
+    return {
+        navigation: nav ? nav.toJSON() : null,
+        resources: resources.map(r => r.toJSON()),
+        paint: paint.map(p => p.toJSON()),
+        memory: memory,
+    };
+}
+"""
+
+# JavaScript to collect Core Web Vitals (LCP, CLS) via PerformanceObserver with buffered:true
+VITALS_COLLECT_JS = """
+() => new Promise((resolve) => {
+    const vitals = { lcp: null, cls: 0 };
+    try {
+        new PerformanceObserver((list) => {
+            const entries = list.getEntries();
+            if (entries.length > 0) {
+                vitals.lcp = entries[entries.length - 1].startTime;
+            }
+        }).observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch (e) {}
+    try {
+        new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                if (!entry.hadRecentInput) vitals.cls += entry.value;
+            }
+        }).observe({ type: 'layout-shift', buffered: true });
+    } catch (e) {}
+    setTimeout(() => resolve(vitals), 100);
+})
+"""
+
+
+class PerformanceCollector:
+    """Collects performance metrics from a browser page via Performance API."""
+
+    def __init__(self, page: Page) -> None:
+        self._page = page
+
+    def _collect_perf(self) -> PerfData:
+        """Execute PERF_COLLECT_JS once and return the result."""
+        return self._page.evaluate(PERF_COLLECT_JS)  # type: ignore[no-any-return]
+
+    def collect_all(self) -> PerfData:
+        """Collect all available performance metrics."""
+        base = self._collect_perf()
+        base["vitals"] = self._page.evaluate(VITALS_COLLECT_JS)
+        return base
+
+    def collect_navigation(self) -> NavigationTiming | None:
+        """Collect navigation timing metrics."""
+        return self._collect_perf()["navigation"]
+
+    def collect_resources(self) -> list[ResourceTiming]:
+        """Collect resource timing entries."""
+        return self._collect_perf()["resources"]
+
+    def collect_vitals(self) -> VitalsInfo:
+        """Collect Core Web Vitals (LCP, CLS)."""
+        return self._page.evaluate(VITALS_COLLECT_JS)  # type: ignore[no-any-return]
+
+    def collect_memory(self) -> MemoryInfo | None:
+        """Collect memory usage (Chrome-only)."""
+        return self._collect_perf()["memory"]
+
+
+def format_navigation(nav: NavigationTiming | None) -> list[str]:
+    """Format navigation timing as human-readable lines."""
+    if not nav:
+        return ["  (no navigation data)"]
+    lines: list[str] = []
+    ttfb = nav.get("responseStart", 0) - nav.get("requestStart", 0)
+    dom_interactive = nav.get("domInteractive", 0)
+    dom_complete = nav.get("domComplete", 0)
+    load_event = nav.get("loadEventEnd", 0)
+    lines.append(f"  TTFB ................ {ttfb:.0f} ms")
+    lines.append(f"  DOM Interactive ..... {dom_interactive:.0f} ms")
+    lines.append(f"  DOM Complete ........ {dom_complete:.0f} ms")
+    lines.append(f"  Page Load ........... {load_event:.0f} ms")
+    return lines
+
+
+def format_resources(resources: list[ResourceTiming]) -> list[str]:
+    """Format resource timing summary as human-readable lines."""
+    if not resources:
+        return ["  (no resources)"]
+    total_size = sum(r.get("transferSize", 0) for r in resources)
+    sorted_by_duration = sorted(resources, key=lambda r: r.get("duration", 0), reverse=True)
+    top5 = sorted_by_duration[:5]
+    lines = [f"  Resources: {len(resources)} loaded ({_format_bytes(total_size)} total)"]
+    if top5:
+        slowest = ", ".join(f"{_short_url(r.get('name', '?'))} ({r.get('duration', 0):.0f}ms)" for r in top5)
+        lines.append(f"  Slowest: {slowest}")
+    return lines
+
+
+def format_vitals(vitals: VitalsInfo) -> list[str]:
+    """Format Core Web Vitals as human-readable lines."""
+    lines: list[str] = []
+    lcp = vitals.get("lcp")
+    cls_val = vitals.get("cls", 0)
+    lcp_str = f"{lcp:.0f} ms" if lcp is not None else "N/A"
+    lines.append(f"  LCP ................. {lcp_str}")
+    lines.append(f"  CLS ................. {cls_val:.3f}")
+    return lines
+
+
+def format_memory(memory: MemoryInfo | None) -> list[str]:
+    """Format memory usage as human-readable lines."""
+    if not memory:
+        return ["  (not available)"]
+    used = memory.get("usedJSHeapSize", 0)
+    total = memory.get("totalJSHeapSize", 0)
+    return [f"  JS Heap Used ........ {_format_bytes(used)} / {_format_bytes(total)}"]
+
+
+def format_paint(paint: list[PaintTiming]) -> list[str]:
+    """Format paint timing as human-readable lines."""
+    if not paint:
+        return ["  (no paint data)"]
+    lines: list[str] = []
+    for entry in paint:
+        name = entry.get("name", "unknown")
+        start = entry.get("startTime", 0)
+        label = (
+            "First Paint"
+            if name == "first-paint"
+            else "First Contentful Paint" if name == "first-contentful-paint" else name
+        )
+        lines.append(f"  {label} .. {start:.0f} ms")
+    return lines
+
+
+def _format_bytes(n: int | float) -> str:
+    """Format byte count as human-readable string."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"
+
+
+def _short_url(url: str) -> str:
+    """Extract path from URL for display."""
+    if "/" in url:
+        parts = url.split("/")
+        return "/" + parts[-1] if parts[-1] else url
+    return url

--- a/src/nova_act/cli/browser/services/screenshot_annotator.py
+++ b/src/nova_act/cli/browser/services/screenshot_annotator.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Screenshot annotation service — overlay bounding boxes and ref labels on screenshots."""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+
+from PIL import Image, ImageDraw, ImageFont
+
+if TYPE_CHECKING:
+    from playwright.sync_api import FloatRect, Page
+
+    from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement
+
+# Color-code by role
+ROLE_COLORS: dict[str, str] = {
+    "button": "#3B82F6",  # blue
+    "link": "#22C55E",  # green
+    "textbox": "#F97316",  # orange
+    "searchbox": "#F97316",
+    "combobox": "#F97316",
+    "checkbox": "#A855F7",  # purple
+    "radio": "#A855F7",
+    "switch": "#A855F7",
+    "slider": "#EAB308",  # yellow
+    "spinbutton": "#EAB308",
+    "tab": "#06B6D4",  # cyan
+    "menuitem": "#06B6D4",
+}
+DEFAULT_COLOR = "#EF4444"  # red
+
+INTERACTIVE_ROLES = frozenset(
+    {
+        "button",
+        "link",
+        "textbox",
+        "checkbox",
+        "radio",
+        "combobox",
+        "menuitem",
+        "tab",
+        "switch",
+        "slider",
+        "searchbox",
+        "spinbutton",
+    }
+)
+
+# Annotation rendering constants
+FILL_ALPHA = 40
+LABEL_BG_ALPHA = 200
+OUTLINE_WIDTH = 2
+LABEL_PADDING_X = 6
+LABEL_PADDING_Y = 4
+TEXT_OFFSET_X = 3
+TEXT_OFFSET_Y = 1
+
+
+def _color_for_role(role: str) -> str:
+    return ROLE_COLORS.get(role, DEFAULT_COLOR)
+
+
+def _hex_to_rgba(hex_color: str, alpha: int = 255) -> tuple[int, int, int, int]:
+    h = hex_color.lstrip("#")
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16), alpha)
+
+
+def annotate_screenshot(
+    screenshot_bytes: bytes,
+    elements_with_boxes: list[tuple[SnapshotElement, FloatRect]],
+) -> bytes:
+    """Overlay bounding boxes and ref labels on a screenshot.
+
+    Args:
+        screenshot_bytes: Raw PNG/JPEG screenshot bytes.
+        elements_with_boxes: List of (SnapshotElement, bbox_dict) where bbox_dict
+            has keys x, y, width, height.
+
+    Returns:
+        Annotated PNG image bytes.
+    """
+    img = Image.open(io.BytesIO(screenshot_bytes)).convert("RGBA")
+    overlay = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+    font = ImageFont.load_default()
+
+    for elem, bbox in elements_with_boxes:
+        x, y, w, h = bbox["x"], bbox["y"], bbox["width"], bbox["height"]
+        color_hex = _color_for_role(elem.role)
+        outline_color = _hex_to_rgba(color_hex)
+        fill_color = _hex_to_rgba(color_hex, alpha=FILL_ALPHA)
+
+        # Semi-transparent fill + solid outline
+        draw.rectangle([x, y, x + w, y + h], fill=fill_color, outline=outline_color, width=OUTLINE_WIDTH)
+
+        # Label background + text
+        label = elem.ref
+        label_bbox = font.getbbox(label)
+        label_w = label_bbox[2] - label_bbox[0] + LABEL_PADDING_X
+        label_h = label_bbox[3] - label_bbox[1] + LABEL_PADDING_Y
+        label_bg = _hex_to_rgba(color_hex, alpha=LABEL_BG_ALPHA)
+        draw.rectangle([x, y - label_h, x + label_w, y], fill=label_bg)
+        draw.text((x + TEXT_OFFSET_X, y - label_h + TEXT_OFFSET_Y), label, fill=(255, 255, 255, 255), font=font)
+
+    result = Image.alpha_composite(img, overlay).convert("RGB")
+    buf = io.BytesIO()
+    result.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def resolve_element_boxes(
+    page: Page,
+    elements: list[SnapshotElement],
+    role_filter: frozenset[str] | None = None,
+) -> list[tuple[SnapshotElement, FloatRect]]:
+    """Resolve bounding boxes for snapshot elements via Playwright locators.
+
+    Args:
+        page: Playwright Page object.
+        elements: Flattened snapshot elements.
+        role_filter: If provided, only include elements with these roles.
+            If None, defaults to INTERACTIVE_ROLES.
+
+    Returns:
+        List of (element, bbox_dict) for elements with valid bounding boxes.
+    """
+    allowed_roles = role_filter if role_filter is not None else INTERACTIVE_ROLES
+    results: list[tuple[SnapshotElement, FloatRect]] = []
+
+    for elem in elements:
+        if not elem.role or elem.role not in allowed_roles:
+            continue
+        if not elem.name:
+            continue
+        try:
+            locator = page.get_by_role(elem.role, name=elem.name).first  # type: ignore[arg-type]
+            bbox = locator.bounding_box()
+            if bbox:
+                results.append((elem, bbox))
+        except Exception:
+            continue
+
+    return results

--- a/src/nova_act/cli/browser/services/session/__init__.py
+++ b/src/nova_act/cli/browser/services/session/__init__.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session management services."""
+
+from nova_act.cli.browser.services.session.cdp_endpoint_manager import (
+    CdpEndpointManager,
+)
+from nova_act.cli.browser.services.session.chrome_launcher import ChromeLauncher
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.closer import SessionCloser
+from nova_act.cli.browser.services.session.connector import NovaActConnector
+from nova_act.cli.browser.services.session.locking import SessionLockManager
+from nova_act.cli.browser.services.session.manager import (
+    ACTIVE_SESSION_STATES,
+    SessionManager,
+    filter_active_sessions,
+)
+from nova_act.cli.browser.services.session.models import (
+    BrowserOptions,
+    BrowserSource,
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.core.exceptions import SessionLockTimeout, SessionNotFoundError
+
+__all__ = [
+    "ACTIVE_SESSION_STATES",
+    "BrowserOptions",
+    "BrowserSource",
+    "CdpEndpointManager",
+    "ChromeLauncher",
+    "ChromeTerminator",
+    "NovaActConnector",
+    "SessionCloser",
+    "SessionInfo",
+    "SessionLockManager",
+    "SessionLockTimeout",
+    "SessionManager",
+    "SessionNotFoundError",
+    "SessionPersistence",
+    "SessionState",
+    "filter_active_sessions",
+]

--- a/src/nova_act/cli/browser/services/session/cdp_endpoint_manager.py
+++ b/src/nova_act/cli/browser/services/session/cdp_endpoint_manager.py
@@ -1,0 +1,197 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CDP endpoint discovery and validation.
+
+Chrome DevTools Protocol (CDP) is a debugging protocol that allows tools to
+instrument, inspect, and debug Chromium-based browsers. Chrome exposes a
+WebSocket endpoint (e.g., ws://localhost:9222) that clients connect to for
+remote control. This module handles discovering, parsing, and validating
+those CDP endpoints.
+"""
+
+import logging
+import re
+import time
+from urllib.parse import urlparse, urlunparse
+
+import requests
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+
+logger = logging.getLogger(__name__)
+
+_WS_PREFIX = "ws://"
+_WSS_PREFIX = "wss://"
+_WS_PREFIXES = (_WS_PREFIX, _WSS_PREFIX)
+
+_MIN_PORT = 1
+_MAX_PORT = 65535
+
+
+def is_websocket_endpoint(endpoint: str) -> bool:
+    """Check if endpoint string is a WebSocket URL (ws:// or wss://)."""
+    return endpoint.startswith(_WS_PREFIXES)
+
+
+def validate_port(port: int) -> None:
+    """Validate port is in valid TCP range (1-65535).
+
+    Raises:
+        ValueError: If port is out of range.
+    """
+    if port < _MIN_PORT or port > _MAX_PORT:
+        raise ValueError(f"Port number must be between {_MIN_PORT} and {_MAX_PORT}, got {port}")
+
+
+def swap_ws_to_http(endpoint: str) -> str:
+    """Convert a WebSocket URL to its HTTP equivalent.
+
+    ws://host:port  -> http://host:port
+    wss://host:port -> https://host:port
+    """
+    return endpoint.replace(_WS_PREFIX, "http://").replace(_WSS_PREFIX, "https://")
+
+
+class CdpEndpointManager:
+    """Discovers, parses, and validates Chrome DevTools Protocol (CDP) endpoints.
+
+    CDP endpoints are WebSocket URLs that Chrome exposes for remote debugging.
+    This class provides methods to:
+    - Parse user-provided endpoints (port numbers or ws:// URLs)
+    - Poll a launched Chrome instance until its CDP endpoint becomes available
+    - Validate that an endpoint is reachable and returns a debugger URL
+    - Auto-discover running Chrome instances via DevToolsActivePort files or port probing
+    """
+
+    def parse_cdp_endpoint(self, cdp_endpoint: str) -> str:
+        """Parse CDP endpoint into WebSocket URL format.
+
+        Supports:
+        - Port number: "9222" -> "ws://localhost:9222"
+        - Full WebSocket URL: "ws://localhost:9222" -> "ws://localhost:9222"
+
+        Args:
+            cdp_endpoint: CDP endpoint (port or ws:// URL)
+
+        Returns:
+            WebSocket URL in format "ws://host:port"
+
+        Raises:
+            ValueError: If endpoint format is invalid
+        """
+        cdp_endpoint = cdp_endpoint.strip()
+
+        if is_websocket_endpoint(cdp_endpoint):
+            return cdp_endpoint
+
+        try:
+            port = int(cdp_endpoint)
+        except ValueError:
+            raise ValueError(
+                f"Invalid CDP endpoint format: '{cdp_endpoint}'. "
+                "Expected port number (e.g., 9222) or WebSocket URL (e.g., ws://localhost:9222)"
+            )
+        validate_port(port)
+        return f"{_WS_PREFIX}localhost:{port}"
+
+    def extract_port_from_endpoint(self, endpoint: str) -> int | None:
+        """Extract port number from WebSocket URL.
+
+        Args:
+            endpoint: WebSocket URL (e.g., "ws://localhost:9222")
+
+        Returns:
+            Port number or None if not found
+        """
+        match = re.search(r":(\d+)", endpoint)
+        return int(match.group(1)) if match else None
+
+    def _extract_websocket_url(self, url: str, timeout: int) -> str:
+        """Extract WebSocket debugger URL from CDP /json/version endpoint.
+
+        Args:
+            url: HTTP URL to CDP /json/version endpoint
+            timeout: Request timeout in seconds
+
+        Returns:
+            WebSocket debugger URL
+
+        Raises:
+            requests.RequestException: If request fails
+            KeyError: If response missing webSocketDebuggerUrl
+        """
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        data: dict[str, object] = response.json()
+        return str(data["webSocketDebuggerUrl"])
+
+    def validate_cdp_endpoint(self, endpoint: str) -> str:
+        """Validate that CDP endpoint is reachable and return WebSocket debugger URL.
+
+        Converts the ws:// endpoint to http:// to query Chrome's /json/version
+        API, which returns the full WebSocket debugger URL for connection.
+
+        Args:
+            endpoint: WebSocket URL to validate (e.g., "ws://localhost:9222")
+
+        Returns:
+            WebSocket debugger URL from CDP endpoint
+
+        Raises:
+            RuntimeError: If endpoint is not reachable or invalid
+        """
+        http_url = swap_ws_to_http(endpoint)
+        # Strip any browser path (e.g., /devtools/browser/abc123) — /json/version
+        # must be queried at the root: http://host:port/json/version
+        parsed = urlparse(http_url)
+        base_url = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+        try:
+            return self._extract_websocket_url(
+                f"{base_url}/json/version",
+                DefaultBrowserConfig.CDP_VERSION_CHECK_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as e:
+            raise RuntimeError(f"CDP endpoint '{endpoint}' is not reachable: {e}")
+        except KeyError as e:
+            raise RuntimeError(f"CDP endpoint '{endpoint}' did not return webSocketDebuggerUrl") from e
+
+    def get_cdp_endpoint(self, port: int, timeout: int | None = None) -> str:
+        """Poll Chrome CDP endpoint until it becomes available.
+
+        Chrome takes a moment to start its CDP server after launch. This method
+        repeatedly queries /json/version until a WebSocket URL is returned or
+        the timeout expires.
+
+        Args:
+            port: CDP port to poll
+            timeout: Maximum seconds to wait for endpoint (default: CDP_ENDPOINT_TIMEOUT_SECONDS)
+
+        Returns:
+            WebSocket debugger URL
+
+        Raises:
+            RuntimeError: If CDP endpoint not available within timeout
+        """
+        timeout = timeout if timeout is not None else DefaultBrowserConfig.CDP_ENDPOINT_TIMEOUT_SECONDS
+        url = f"http://localhost:{port}/json/version"
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                return self._extract_websocket_url(url, DefaultBrowserConfig.CDP_POLL_REQUEST_TIMEOUT_SECONDS)
+            except (requests.RequestException, KeyError):
+                time.sleep(DefaultBrowserConfig.CDP_ENDPOINT_POLL_INTERVAL_SECONDS)
+
+        raise RuntimeError(f"CDP endpoint not available after {timeout}s")

--- a/src/nova_act/cli/browser/services/session/chrome_launcher.py
+++ b/src/nova_act/cli/browser/services/session/chrome_launcher.py
@@ -1,0 +1,367 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chrome browser launcher and CDP endpoint management.
+
+Handles detecting Chrome installations, launching Chrome with remote debugging
+enabled, and connecting to the resulting CDP endpoint. Supports macOS, Linux,
+and Windows platforms with automatic CI/Docker environment detection.
+"""
+
+import logging
+import os
+import socket
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.services.session.cdp_endpoint_manager import (
+    CdpEndpointManager,
+)
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.core.process import is_process_running
+
+logger = logging.getLogger(__name__)
+
+# Platform -> list of candidate Chrome executable paths
+_CHROME_PATHS: dict[str, list[str]] = {
+    "darwin": ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+    "linux": ["/usr/bin/google-chrome", "/usr/bin/chromium-browser"],
+    "win32": [
+        os.path.join(os.environ.get("PROGRAMFILES", ""), "Google", "Chrome", "Application", "chrome.exe"),
+        os.path.join(os.environ.get("PROGRAMFILES(X86)", ""), "Google", "Chrome", "Application", "chrome.exe"),
+        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Google", "Chrome", "Application", "chrome.exe"),
+    ],
+}
+
+
+@dataclass(frozen=True)
+class ProfileResolution:
+    """Result of resolving a browser profile path to Chrome launch parameters."""
+
+    user_data_dir: Path
+    profile_directory: str | None = None
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    """Result of launching Chrome with CDP."""
+
+    process: subprocess.Popen[bytes]
+    ws_url: str
+    port: int
+    user_data_dir: Path
+
+
+class ChromeLauncher:
+    """Launches Chrome with remote debugging and manages the browser process lifecycle.
+
+    Responsible for:
+    - Detecting Chrome installations across macOS, Linux, and Windows
+    - Finding available CDP ports (avoiding conflicts with other sessions)
+    - Launching Chrome with appropriate flags for remote debugging
+    - Connecting to the CDP endpoint after launch
+    - Resolving and validating user-provided browser profiles
+    """
+
+    def __init__(self, session_dir: str, get_used_ports_callback: Callable[[], set[int]]) -> None:
+        """Initialize Chrome launcher.
+
+        Args:
+            session_dir: Directory for session storage
+            get_used_ports_callback: Callback to get ports currently in use
+        """
+        self.session_dir = session_dir
+        self._get_used_ports = get_used_ports_callback
+        self.cdp_manager = CdpEndpointManager()
+        self._terminator = ChromeTerminator()
+
+    def find_available_port(self, start_port: int | None = None, end_port: int | None = None) -> int:
+        """Find available port in range for CDP.
+
+        We manually probe ports rather than letting Chrome auto-select because we
+        need to know the port upfront to poll /json/version for the WebSocket URL.
+        Chrome's --remote-debugging-port=0 would auto-select, but doesn't reliably
+        report the chosen port back to the parent process.
+
+        Note: This is a best-effort check with an inherent TOCTOU race condition —
+        the port could be claimed by another process between our check and Chrome's
+        bind. The caller handles this via try/except around Chrome launch.
+
+        Args:
+            start_port: Start of port range (default: CDP_PORT_RANGE_START)
+            end_port: End of port range (default: CDP_PORT_RANGE_END)
+
+        Returns:
+            Available port number
+
+        Raises:
+            RuntimeError: If no available ports in range
+        """
+        start_port = start_port or DefaultBrowserConfig.CDP_PORT_RANGE_START
+        end_port = end_port or DefaultBrowserConfig.CDP_PORT_RANGE_END
+
+        used_ports = self._get_used_ports()
+
+        for port in range(start_port, end_port + 1):
+            if port in used_ports:
+                continue
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                try:
+                    s.bind(("localhost", port))
+                    return port
+                except OSError:
+                    continue
+        raise RuntimeError(f"No available ports in range {start_port}-{end_port}")
+
+    def detect_chrome_path(self) -> str:
+        """Detect Chrome executable for current platform.
+
+        Checks (in order): CHROME_PATH env var, then platform-specific known paths.
+
+        Returns:
+            Path to Chrome executable
+
+        Raises:
+            RuntimeError: If Chrome not found
+        """
+        if chrome_path := os.getenv("CHROME_PATH"):
+            if os.path.exists(chrome_path):
+                return chrome_path
+
+        for path in _CHROME_PATHS.get(sys.platform, []):
+            if os.path.exists(path):
+                return path
+
+        raise RuntimeError(
+            "Chrome/Chromium not found. To fix:\n"
+            "  1. Install Google Chrome: https://www.google.com/chrome/\n"
+            "  2. Or set CHROME_PATH env var: export CHROME_PATH=/path/to/chrome\n"
+            "  3. Or use --executable-path flag: act browser session create --executable-path /path/to/chrome <url>"
+        )
+
+    def _validate_browser_executable(self, executable_path: str) -> None:
+        """Validate browser executable exists, is executable, and is Chromium-based.
+
+        Args:
+            executable_path: Path to browser executable
+
+        Raises:
+            RuntimeError: If executable is invalid or not Chromium-based
+        """
+        if not os.path.exists(executable_path):
+            raise RuntimeError(f"Browser executable not found: {executable_path}")
+        if not os.access(executable_path, os.X_OK):
+            raise RuntimeError(f"Browser executable is not executable: {executable_path}")
+
+        try:
+            result = subprocess.run(
+                [executable_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=DefaultBrowserConfig.BROWSER_VERSION_CHECK_TIMEOUT_SECONDS,
+            )
+            version_output = result.stdout.lower()
+            is_chromium = any(indicator in version_output for indicator in ["chrome", "chromium", "edge"])
+            if not is_chromium:
+                raise RuntimeError(f"Browser is not Chromium-based: {executable_path}")
+        except (subprocess.TimeoutExpired, subprocess.SubprocessError) as e:
+            raise RuntimeError(f"Failed to verify browser type for {executable_path}: {e}") from e
+
+    def _resolve_user_data_directory(self, session_id: str, profile_path: str | None) -> ProfileResolution:
+        """Resolve user data directory from profile path or create new session directory.
+
+        When the profile path points to a Chrome profile subdirectory (e.g. Default/),
+        detects this by checking if the parent contains 'Local State' and returns
+        the parent as user_data_dir with the subdirectory name as profile_directory.
+
+        Args:
+            session_id: Unique identifier for the session
+            profile_path: Optional path to existing browser profile directory
+
+        Returns:
+            ProfileResolution with user_data_dir and optional profile_directory
+
+        Raises:
+            RuntimeError: If profile path is invalid or locked
+        """
+        if profile_path:
+            profile_dir = Path(profile_path).expanduser().resolve()
+            if not profile_dir.exists():
+                raise RuntimeError(f"Profile directory not found: {profile_path}")
+            if not profile_dir.is_dir():
+                raise RuntimeError(f"Profile path is not a directory: {profile_path}")
+
+            preferences_file = profile_dir / "Preferences"
+            if not preferences_file.exists():
+                raise RuntimeError(f"Invalid profile: missing Preferences file in {profile_path}")
+
+            # Best-effort lock check: another Chrome instance could acquire the lock
+            # between this check and our launch. The caller handles launch failures
+            # via try/except, so this race window is acceptable.
+            lock_file = profile_dir / "SingletonLock"
+            if lock_file.is_symlink() or lock_file.exists():
+                if self._is_lock_stale(lock_file):
+                    lock_file.unlink(missing_ok=True)
+                else:
+                    raise RuntimeError(f"Profile is locked (in use by another browser): {profile_path}")
+
+            # Detect Chrome profile subdirectory: if the parent has 'Local State',
+            # this is a profile subdir (e.g. Default/, Profile 1/) inside a Chrome
+            # user data directory. Chrome expects --user-data-dir to be the parent.
+            parent_local_state = profile_dir.parent / "Local State"
+            if parent_local_state.exists():
+                return ProfileResolution(
+                    user_data_dir=profile_dir.parent,
+                    profile_directory=profile_dir.name,
+                )
+
+            return ProfileResolution(user_data_dir=profile_dir)
+        else:
+            user_data_dir = Path(self.session_dir) / session_id / "profile"
+            user_data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(user_data_dir, 0o700)
+            return ProfileResolution(user_data_dir=user_data_dir)
+
+    def _is_lock_stale(self, lock_file: Path) -> bool:
+        """Check if a SingletonLock is stale (owning process no longer running).
+
+        Chrome creates SingletonLock as a symlink to 'hostname-pid'. If the PID
+        is no longer running, the lock is stale and safe to remove.
+
+        Returns False (not stale) on error to avoid data corruption from
+        two Chrome instances sharing the same profile directory.
+        """
+        try:
+            target = os.readlink(str(lock_file))
+            # Format: "hostname-pid"
+            pid_str = target.rsplit("-", 1)[-1]
+            pid = int(pid_str)
+            return not is_process_running(pid)
+        except (OSError, ValueError, IndexError):
+            # Can't determine lock owner — fail-closed to prevent profile corruption
+            # from concurrent Chrome instances. User can manually remove the lock.
+            return False
+
+    @staticmethod
+    def _detect_ci_environment() -> bool:
+        """Detect if running in a CI/Docker environment."""
+        ci_env_vars = ("CI", "GITHUB_ACTIONS", "JENKINS_URL", "GITLAB_CI", "CODEBUILD_BUILD_ID", "TF_BUILD")
+        if any(os.getenv(var) for var in ci_env_vars):
+            return True
+        return Path("/.dockerenv").exists()
+
+    def _build_chrome_arguments(
+        self, chrome_path: str, port: int, user_data_dir: Path, headless: bool, launch_args: list[str] | None = None
+    ) -> list[str]:
+        """Build Chrome launch arguments.
+
+        Args:
+            chrome_path: Path to Chrome executable
+            port: CDP port number
+            user_data_dir: User data directory path
+            headless: Whether to launch in headless mode
+            launch_args: Additional Chrome launch arguments
+
+        Returns:
+            List of command-line arguments
+        """
+        args = [
+            chrome_path,
+            f"--remote-debugging-port={port}",
+            f"--user-data-dir={user_data_dir}",
+            f"--window-size={DefaultBrowserConfig.DEFAULT_WINDOW_SIZE}",
+            "--no-first-run",
+            "--remote-allow-origins=http://localhost",
+        ]
+        if headless:
+            args.append("--headless=new")
+        if self._detect_ci_environment():
+            args.extend(["--no-sandbox", "--disable-dev-shm-usage"])
+        if launch_args:
+            args.extend(launch_args)
+        return args
+
+    def _launch_and_connect(self, args: list[str], port: int) -> tuple[subprocess.Popen[bytes], str]:
+        """Launch Chrome process and connect to CDP endpoint.
+
+        Args:
+            args: Chrome launch arguments
+            port: CDP port number
+
+        Returns:
+            Tuple of (Chrome process, WebSocket URL)
+
+        Raises:
+            RuntimeError: If CDP endpoint not available
+        """
+        process = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+        try:
+            ws_url = self.cdp_manager.get_cdp_endpoint(port)
+            return process, ws_url
+        except BaseException:
+            self._terminator.terminate(process.pid)
+            try:
+                process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+            raise
+
+    def launch_chrome_with_cdp(
+        self,
+        session_id: str,
+        headless: bool,
+        executable_path: str | None = None,
+        profile_path: str | None = None,
+        launch_args: list[str] | None = None,
+    ) -> LaunchResult:
+        """Launch Chrome with CDP, return LaunchResult with process, ws_url, port, user_data_dir.
+
+        Resolves the Chrome executable, validates it, finds an available port,
+        sets up the user data directory, then launches Chrome and waits for the
+        CDP endpoint to become available.
+
+        Args:
+            session_id: Unique identifier for the session
+            headless: Whether to launch in headless mode
+            executable_path: Optional path to custom Chromium-based browser executable
+            profile_path: Optional path to existing browser profile directory
+            launch_args: Additional Chrome launch arguments
+
+        Returns:
+            LaunchResult containing Chrome process, WebSocket URL, CDP port, and user data directory
+
+        Raises:
+            RuntimeError: If Chrome launch fails or CDP endpoint not available
+        """
+        chrome_path = executable_path if executable_path else self.detect_chrome_path()
+        self._validate_browser_executable(chrome_path)
+
+        port = self.find_available_port()
+        resolution = self._resolve_user_data_directory(session_id, profile_path)
+
+        effective_launch_args = list(launch_args) if launch_args else []
+        if resolution.profile_directory:
+            effective_launch_args.append(f"--profile-directory={resolution.profile_directory}")
+
+        args = self._build_chrome_arguments(
+            chrome_path, port, resolution.user_data_dir, headless, effective_launch_args or None
+        )
+
+        process, ws_url = self._launch_and_connect(args, port)
+        return LaunchResult(process=process, ws_url=ws_url, port=port, user_data_dir=resolution.user_data_dir)

--- a/src/nova_act/cli/browser/services/session/chrome_terminator.py
+++ b/src/nova_act/cli/browser/services/session/chrome_terminator.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chrome process termination."""
+
+import logging
+import os
+import time
+
+import psutil
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.core.process import is_process_running
+
+logger = logging.getLogger(__name__)
+
+
+class ChromeTerminator:
+    """Terminates Chrome browser processes."""
+
+    def terminate(self, pid: int | None) -> None:
+        """Terminate Chrome process gracefully, force kill if needed.
+
+        Args:
+            pid: Process ID to terminate (None if no process)
+        """
+        if not pid or not is_process_running(pid):
+            return
+
+        try:
+            process = psutil.Process(pid)
+            if not any(name in process.name().lower() for name in DefaultBrowserConfig.BROWSER_PROCESS_NAMES):
+                return
+
+            os.kill(pid, DefaultBrowserConfig.CHROME_TERMINATION_SIGNAL)
+            time.sleep(DefaultBrowserConfig.CHROME_TERMINATION_GRACE_PERIOD_SECONDS)
+            if is_process_running(pid):
+                os.kill(pid, DefaultBrowserConfig.CHROME_FORCE_KILL_SIGNAL)
+        except (ProcessLookupError, PermissionError, psutil.NoSuchProcess, psutil.AccessDenied) as e:
+            logger.debug("Failed to terminate Chrome process %s: %s", pid, e)

--- a/src/nova_act/cli/browser/services/session/closer.py
+++ b/src/nova_act/cli/browser/services/session/closer.py
@@ -1,0 +1,185 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session closing logic for interactive Nova Act CLI.
+
+Handles the various close scenarios: normal close, force close, and failed session cleanup.
+"""
+
+import json
+import logging
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+import click
+
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.locking import SessionLockManager
+from nova_act.cli.browser.services.session.models import (
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.browser.utils.log_capture import suppress_sdk_output
+from nova_act.cli.core.config import get_cli_config_dir
+from nova_act.cli.core.exceptions import SessionNotFoundError
+from nova_act.cli.core.output import is_verbose_mode
+
+logger = logging.getLogger(__name__)
+
+_CLI_CONFIG_DIR = get_cli_config_dir()
+
+
+class SessionCloser:
+    """Handles session closing operations.
+
+    Separates close logic from SessionManager to reduce complexity and improve testability.
+    """
+
+    def __init__(
+        self,
+        lock_manager: SessionLockManager,
+        chrome_terminator: ChromeTerminator,
+        persistence: SessionPersistence,
+    ):
+        """Initialize SessionCloser with required dependencies.
+
+        Args:
+            lock_manager: Manages session locks
+            chrome_terminator: Handles Chrome process termination
+            persistence: Handles session metadata persistence
+        """
+        self._lock_manager = lock_manager
+        self._chrome_terminator = chrome_terminator
+        self._persistence = persistence
+
+    def load_session_for_close(
+        self, session_id: str, force: bool, sessions: dict[str, SessionInfo], get_session: Callable[[str], SessionInfo]
+    ) -> SessionInfo:
+        """Load session info for closing, bypassing validation if force=True."""
+        if force:
+            if session_id in sessions:
+                return sessions[session_id]
+
+            try:
+                return self._persistence.load_session(session_id)
+            except (FileNotFoundError, json.JSONDecodeError, KeyError, ValueError):
+                raise SessionNotFoundError(f"Session '{session_id}' not found")
+
+        return get_session(session_id)
+
+    def _cleanup_lock(self, session_id: str) -> None:
+        """Clean up session lock from memory and filesystem.
+
+        Args:
+            session_id: ID of session to clean up lock for
+        """
+        self._lock_manager.remove_lock(session_id)
+
+    def _cleanup_session_files(self, session_id: str, sessions: dict[str, SessionInfo]) -> None:
+        """Remove session metadata file and in-memory reference.
+
+        Args:
+            session_id: ID of session to clean up
+            sessions: In-memory session dictionary
+        """
+        file_path = self._persistence.get_session_file_path(session_id)
+        if file_path.exists():
+            file_path.unlink()
+
+        if session_id in sessions:
+            del sessions[session_id]
+
+    def _cleanup_user_data_dir(self, session_info: SessionInfo) -> None:
+        """Remove Chrome user data directory if it's a managed directory.
+
+        Only deletes directories under the CLI config dir (managed by us).
+        User-provided --profile-path directories are NOT deleted.
+
+        Args:
+            session_info: Session whose user_data_dir to clean up
+        """
+        user_data_dir = session_info.user_data_dir
+        if not user_data_dir:
+            return
+        profile_path = None
+        browser_opts = session_info.browser_options_meta
+        if isinstance(browser_opts, dict):
+            raw_profile = browser_opts.get("profile_path")
+            profile_path = str(raw_profile) if raw_profile else None
+        if profile_path and str(Path(profile_path).resolve()) == str(Path(user_data_dir).resolve()):
+            return
+        # Safety guard: only delete directories under CLI config dir to prevent
+        # accidental deletion of user Chrome data directories
+        try:
+            Path(user_data_dir).resolve().relative_to(_CLI_CONFIG_DIR.resolve())
+        except ValueError:
+            return
+        shutil.rmtree(user_data_dir, ignore_errors=True)
+
+    def _terminate_browser(self, session_info: SessionInfo) -> None:
+        """Terminate local Chrome browser process."""
+        self._chrome_terminator.terminate(session_info.browser_pid)
+
+    def force_close(self, session_id: str, session_info: SessionInfo, sessions: dict[str, SessionInfo]) -> None:
+        """Force close session: attempt lock, warn if busy, then terminate."""
+        lock_acquired = self._lock_manager.try_acquire(session_id)
+        if not lock_acquired:
+            click.echo(f"Warning: Session '{session_id}' may be in use by another process. " "Force closing anyway.")
+        try:
+            self._terminate_browser(session_info)
+        finally:
+            if lock_acquired:
+                self._lock_manager.release(session_id)
+            self._cleanup_lock(session_id)
+            self._cleanup_user_data_dir(session_info)
+            self._cleanup_session_files(session_id, sessions)
+
+    def cleanup_failed_session(self, session_id: str) -> None:
+        """Clean up lock for failed session, preserving metadata for debugging."""
+        self._cleanup_lock(session_id)
+
+    def normal_close(self, session_id: str, session_info: SessionInfo, sessions: dict[str, SessionInfo]) -> None:
+        """Normal close: stop NovaAct, terminate browser (local or cloud), and clean up."""
+        session_info.state = SessionState.STOPPING
+        error: Exception | None = None
+
+        try:
+            if session_info.nova_act_instance:
+                if is_verbose_mode():
+                    session_info.nova_act_instance.stop()
+                else:
+                    with suppress_sdk_output():
+                        session_info.nova_act_instance.stop()
+
+            self._terminate_browser(session_info)
+            session_info.state = SessionState.STOPPED
+        except Exception as e:
+            error = e
+            session_info.state = SessionState.FAILED
+            session_info.error_message = str(e)
+        finally:
+            self._persistence.write_session_metadata(session_info)
+
+            try:
+                self._cleanup_lock(session_id)
+            except Exception:
+                logger.debug("Failed to clean up lock for session '%s'", session_id, exc_info=True)
+
+            if session_info.state == SessionState.STOPPED:
+                self._cleanup_user_data_dir(session_info)
+                self._cleanup_session_files(session_id, sessions)
+
+        if error is not None:
+            raise RuntimeError(f"Failed to stop session '{session_id}': {error}") from error

--- a/src/nova_act/cli/browser/services/session/connector.py
+++ b/src/nova_act/cli/browser/services/session/connector.py
@@ -1,0 +1,265 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NovaAct instance initialization and connection management."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+from nova_act import NovaAct
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.models import (
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.browser.utils.auth import AuthConfig, AuthMode
+from nova_act.cli.browser.utils.log_capture import get_log_dir, suppress_sdk_output
+from nova_act.cli.core.output import is_verbose_mode
+from nova_act.cli.core.process import is_process_running
+from nova_act.types.workflow import BotoSessionKwargs
+
+if TYPE_CHECKING:
+    from nova_act.types.workflow import Workflow
+
+logger = logging.getLogger(__name__)
+
+
+def _build_boto_kwargs(auth_config: AuthConfig) -> BotoSessionKwargs:
+    """Build boto3.Session kwargs from AuthConfig."""
+    kwargs = BotoSessionKwargs()
+    if auth_config.profile:
+        kwargs["profile_name"] = auth_config.profile
+    if auth_config.region:
+        kwargs["region_name"] = auth_config.region
+    return kwargs
+
+
+class NovaActConnector:
+    """Handles NovaAct instance initialization and browser connection."""
+
+    def __init__(
+        self,
+        persistence: SessionPersistence,
+        chrome_terminator: ChromeTerminator,
+    ) -> None:
+        """Initialize connector with injected dependencies.
+
+        Args:
+            persistence: Session metadata persistence
+            chrome_terminator: Chrome process terminator
+        """
+        self._persistence = persistence
+        self._chrome_terminator = chrome_terminator
+        self._exit_stack: contextlib.ExitStack | None = None
+
+    def connect_to_session(
+        self,
+        session_info: SessionInfo,
+        starting_page: str | None,
+        nova_args: dict[str, object],
+        auth_config: AuthConfig | None = None,
+    ) -> None:
+        """Initialize and start NovaAct instance for session.
+
+        Args:
+            session_info: Session to connect NovaAct to
+            starting_page: Optional URL to navigate to
+            nova_args: Additional NovaAct constructor arguments
+            auth_config: Authentication configuration (None defaults to api-key behavior)
+
+        Raises:
+            RuntimeError: If NovaAct start fails
+        """
+        try:
+            constructor_args = self._build_constructor_args(session_info, nova_args, auth_config)
+            nova_act = self._initialize(constructor_args)
+            self._navigate_to_starting_page(nova_act, starting_page)
+
+            session_info.nova_act_instance = nova_act
+            session_info.state = SessionState.STARTED
+        except Exception as e:
+            self.cleanup_workflow()
+            self._handle_failure(session_info, e)
+            raise RuntimeError(f"Failed to start session '{session_info.session_id}': {e}") from e
+
+    def reconnect_to_session(
+        self,
+        session_info: SessionInfo,
+        auth_config: AuthConfig | None = None,
+    ) -> None:
+        """Reconnect to existing browser session.
+
+        Args:
+            session_info: Session to reconnect
+            auth_config: Authentication configuration (None defaults to api-key behavior)
+
+        Raises:
+            RuntimeError: If reconnection fails
+        """
+        try:
+            constructor_args = self._build_constructor_args(session_info, {}, auth_config)
+            nova_act = self._initialize(constructor_args)
+            session_info.nova_act_instance = nova_act
+            session_info.state = SessionState.STARTED
+        except Exception as e:
+            self.cleanup_workflow()
+            self._handle_failure(session_info, e)
+            sid = session_info.session_id
+            cleanup_hint = f"Clean up with: act browser session close --force --session-id {sid}"
+            if session_info.browser_pid is not None and not is_process_running(session_info.browser_pid):
+                diagnosis = "browser was closed externally"
+            else:
+                diagnosis = "browser is unresponsive (CDP endpoint not reachable)"
+            raise RuntimeError(f"Failed to reconnect to session '{sid}': {diagnosis}. {cleanup_hint}") from e
+
+    def _build_constructor_args(
+        self,
+        session_info: SessionInfo,
+        nova_args: dict[str, object],
+        auth_config: AuthConfig | None = None,
+    ) -> dict[str, object]:
+        """Build NovaAct constructor arguments.
+
+        All sessions connect via CDP endpoint to a CLI-launched Chrome instance.
+
+        For api-key mode (or no auth_config): NovaAct reads env var.
+        For aws mode: ensures workflow definition exists, creates a Workflow, enters it,
+        and passes it to NovaAct.
+
+        Args:
+            session_info: Session metadata
+            nova_args: Additional NovaAct constructor arguments
+            auth_config: Authentication configuration
+        """
+        args = self._build_base_args(session_info, nova_args)
+
+        if auth_config and auth_config.mode == AuthMode.AWS:
+            args["workflow"] = self._setup_aws_workflow(auth_config)
+
+        return args
+
+    @staticmethod
+    def _build_base_args(session_info: SessionInfo, nova_args: dict[str, object]) -> dict[str, object]:
+        """Build common NovaAct constructor arguments (CDP connection, logging, browser options)."""
+        browser_opts = session_info.browser_options_meta
+        ignore_https = browser_opts.get("ignore_https_errors", False) if isinstance(browser_opts, dict) else False
+        log_dir = get_log_dir(session_info.session_id)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        args: dict[str, object] = {
+            "ignore_https_errors": ignore_https,
+            "logs_directory": str(log_dir),
+            "tty": False,
+            "cdp_endpoint_url": session_info.cdp_endpoint,
+            "cdp_use_existing_page": True,
+            **nova_args,
+        }
+        return args
+
+    def _setup_aws_workflow(self, auth_config: AuthConfig) -> Workflow:
+        """Create and enter an AWS Workflow context for authenticated NovaAct usage.
+
+        Args:
+            auth_config: AWS authentication configuration
+
+        Returns:
+            The entered Workflow instance
+        """
+        from nova_act.types.workflow import Workflow  # noqa: PLC0415
+
+        boto_kwargs = _build_boto_kwargs(auth_config)
+        workflow_name = auth_config.workflow_name or "act-cli"
+        self._ensure_workflow_definition(workflow_name, boto_kwargs)
+
+        wf = Workflow(
+            model_id="nova-act-latest",
+            boto_session_kwargs=boto_kwargs,
+            workflow_definition_name=workflow_name,
+        )
+        stack = contextlib.ExitStack()
+        stack.enter_context(wf)  # type: ignore[arg-type]  # Workflow implements __enter__/__exit__
+        self._exit_stack = stack
+        return wf
+
+    def cleanup_workflow(self) -> None:
+        """Clean up active Workflow context if one exists."""
+        if self._exit_stack is not None:
+            try:
+                self._exit_stack.close()
+            except Exception:
+                logger.debug("Failed to clean up workflow", exc_info=True)
+            finally:
+                self._exit_stack = None
+
+    @staticmethod
+    def _ensure_workflow_definition(workflow_name: str, boto_kwargs: BotoSessionKwargs) -> None:
+        """Create workflow definition in AWS if it doesn't exist.
+
+        Idempotent — silently succeeds if the definition already exists (ConflictException).
+        Logs a warning and continues on other failures, letting the SDK surface its own error.
+        """
+        try:
+            from boto3 import Session as BotoSession  # noqa: PLC0415
+            from botocore.exceptions import ClientError  # noqa: PLC0415
+
+            from nova_act.cli.core.clients.nova_act.client import NovaActClient  # noqa: PLC0415
+            from nova_act.cli.core.clients.nova_act.types import CreateWorkflowDefinitionRequest  # noqa: PLC0415
+        except ImportError:
+            logger.debug("boto3 or nova_act client not available — skipping workflow definition auto-creation")
+            return
+
+        try:
+            session = BotoSession(**boto_kwargs)  # type: ignore[arg-type]
+            client = NovaActClient(boto_session=session, region_name=boto_kwargs.get("region_name", "us-east-1"))
+            client.create_workflow_definition(
+                CreateWorkflowDefinitionRequest(name=workflow_name, description="Created by act browser CLI")
+            )
+            logger.info("Created workflow definition '%s'", workflow_name)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "ConflictException":
+                logger.debug("Workflow definition '%s' already exists", workflow_name)
+            else:
+                logger.warning("Could not auto-create workflow definition '%s': %s", workflow_name, e)
+        except Exception as e:
+            logger.warning("Could not auto-create workflow definition '%s': %s", workflow_name, e)
+
+    def _initialize(self, constructor_args: dict[str, object]) -> NovaAct:
+        """Initialize and start NovaAct instance.
+
+        Suppresses SDK stdout/stderr noise (trace logs, thinker dots) unless verbose mode is active.
+        This is the single point where all NovaAct instances are created, so suppression here
+        covers all commands (create, close, close-all, and any prepare_session-based command).
+        """
+        if is_verbose_mode():
+            nova_act = NovaAct(**constructor_args)  # type: ignore[arg-type]
+            nova_act.start()
+        else:
+            with suppress_sdk_output():
+                nova_act = NovaAct(**constructor_args)  # type: ignore[arg-type]
+                nova_act.start()
+        return nova_act
+
+    def _navigate_to_starting_page(self, nova_act: NovaAct, starting_page: str | None) -> None:
+        """Navigate to starting page if provided."""
+        if starting_page and starting_page != "about:blank":
+            nova_act.go_to_url(starting_page)
+
+    def _handle_failure(self, session_info: SessionInfo, error: Exception) -> None:
+        """Handle NovaAct initialization failure."""
+        self._chrome_terminator.terminate(session_info.browser_pid)
+        session_info.state = SessionState.FAILED
+        session_info.error_message = str(error)
+        self._persistence.write_session_metadata(session_info)

--- a/src/nova_act/cli/browser/services/session/locking.py
+++ b/src/nova_act/cli/browser/services/session/locking.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session locking utilities for Nova Act CLI.
+
+Thin wrapper around core/locking.py's FileLockManager for session-specific locking.
+"""
+
+import logging
+from pathlib import Path
+
+from filelock import Timeout as FileLockTimeout
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.core.locking import FileLockManager
+
+logger = logging.getLogger(__name__)
+
+
+class SessionLockManager(FileLockManager):
+    """Manages file-based locks for session operations.
+
+    Extends FileLockManager with browser-specific default timeout.
+    """
+
+    def __init__(self, session_dir: Path):
+        """Initialize the session lock manager.
+
+        Args:
+            session_dir: Directory where session files are stored
+        """
+        super().__init__(session_dir, default_timeout=DefaultBrowserConfig.SESSION_LOCK_TIMEOUT_SECONDS)
+
+    def cleanup_stale_locks(self, known_session_ids: set[str]) -> None:
+        """Remove lock files for sessions that no longer exist on disk or in memory.
+
+        Args:
+            known_session_ids: Set of session IDs currently tracked in memory.
+        """
+        for lock_file in self.lock_dir.glob("*.lock"):
+            session_id = lock_file.stem
+            session_file = self.lock_dir / f"{session_id}.json"
+            if not session_file.exists() and session_id not in known_session_ids:
+                lock_file.unlink(missing_ok=True)
+
+    def try_acquire(self, session_id: str, timeout: float = 2.0) -> bool:
+        """Try to acquire session lock with short timeout.
+
+        Skips acquisition if locking is disabled. Returns True if lock was
+        acquired (or locking is disabled), False if acquisition timed out.
+
+        Args:
+            session_id: Unique identifier for the session
+            timeout: Maximum time to wait for lock acquisition in seconds
+
+        Returns:
+            True if lock acquired or locking disabled, False on timeout
+        """
+        if self._is_locking_disabled():
+            return True
+        lock = self._get_or_create_lock(session_id)
+        try:
+            lock.acquire(timeout=timeout)
+            return True
+        except FileLockTimeout:
+            return False
+
+    def release(self, session_id: str) -> None:
+        """Release a previously acquired session lock.
+
+        Args:
+            session_id: Unique identifier for the session
+        """
+        if self._is_locking_disabled():
+            return
+        lock = self._get_or_create_lock(session_id)
+        try:
+            lock.release()
+        except Exception:
+            logger.debug("Failed to release lock for session '%s'", session_id, exc_info=True)

--- a/src/nova_act/cli/browser/services/session/manager.py
+++ b/src/nova_act/cli/browser/services/session/manager.py
@@ -1,0 +1,674 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session management for interactive Nova Act CLI.
+
+This module provides core session lifecycle management including state tracking,
+session information storage, and session operations (create, get, list, close).
+"""
+
+import json
+import logging
+import os
+import platform
+import re
+from contextlib import AbstractContextManager
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.services.session.chrome_launcher import ChromeLauncher
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.closer import SessionCloser
+from nova_act.cli.browser.services.session.connector import NovaActConnector
+from nova_act.cli.browser.services.session.locking import SessionLockManager
+from nova_act.cli.browser.services.session.models import (
+    BrowserOptions,
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.browser.services.session.pruner import PruneResult, SessionPruner
+from nova_act.cli.core.config import get_browser_cli_dir, get_session_dir
+from nova_act.cli.core.exceptions import (
+    BrowserProcessDead,
+    SessionLimitReached,
+    SessionNotFoundError,
+)
+from nova_act.cli.core.process import is_process_running
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.utils.auth import AuthConfig
+
+# Active session states for filtering
+ACTIVE_SESSION_STATES = frozenset({SessionState.STARTING, SessionState.STARTED})
+
+
+def filter_active_sessions(sessions: list[SessionInfo]) -> list[SessionInfo]:
+    """Filter sessions to only active states (STARTING, STARTED)."""
+    return [s for s in sessions if s.state in ACTIVE_SESSION_STATES]
+
+
+class SessionManager:
+    """Manages Nova Act session lifecycle and state.
+
+    Provides operations to create, retrieve, list, and close browser sessions.
+    Sessions are stored in-memory and tracked by unique session IDs.
+    Thread-safe session operations are supported via session locking.
+    """
+
+    def __init__(self, session_dir: str | None = None) -> None:
+        """Initialize the session manager with empty session storage.
+
+        Args:
+            session_dir: Optional directory path for session storage.
+                        Defaults to the standard session directory.
+
+        Note: Sessions are NOT loaded from disk on initialization to avoid
+        conflicts with active sessions. Use list_sessions() to discover
+        persisted sessions.
+        """
+        self._session_dir = session_dir or str(get_session_dir())
+        self._sessions: dict[str, SessionInfo] = {}
+        self._lock_manager = SessionLockManager(Path(self._session_dir))
+        self._chrome_launcher = ChromeLauncher(self._session_dir, self._get_used_ports)
+        self._chrome_terminator = ChromeTerminator()
+        self._persistence = SessionPersistence(self._session_dir)
+        self._nova_act_connector = NovaActConnector(
+            self._persistence,
+            self._chrome_terminator,
+        )
+        self._session_closer = SessionCloser(
+            self._lock_manager,
+            self._chrome_terminator,
+            self._persistence,
+        )
+        self._session_pruner = SessionPruner(
+            self._persistence,
+            self._chrome_terminator,
+            self._lock_manager,
+        )
+        # No atexit handler and no nova_act.stop() on normal command exit.
+        # CDP browsers persist across CLI invocations and are terminated only
+        # via explicit close_session() calls.
+        #
+        # Design note: each CLI invocation creates a fresh Playwright instance
+        # that connects to the persistent Chrome via CDP. When the process exits
+        # without calling stop(), the OS closes the TCP socket and Chrome cleans
+        # up the DevTools session automatically. Empirical testing (30 rapid-fire
+        # subprocess iterations with navigation, JS eval, screenshots, and a11y
+        # reads — all without stop()) showed 0 failures and stable target counts.
+        # Calling stop() is therefore unnecessary for CDP cleanup and is
+        # intentionally omitted to avoid risk of hangs on teardown.
+
+    def _load_existing_sessions(self) -> None:
+        """Load existing sessions from disk.
+
+        Discovers session metadata files and reconstructs SessionInfo objects.
+        Called from list_sessions() to merge persisted sessions with in-memory state.
+
+        Note: Only loads sessions that don't already exist in memory to avoid
+        overwriting active sessions with nova_act_instance=None.
+
+        All loaded sessions are marked as STOPPED since the browser process
+        is no longer running (sessions don't persist across process restarts).
+        """
+        loaded_sessions = self._persistence.load_existing_sessions(set(self._sessions.keys()))
+        self._sessions.update(loaded_sessions)
+
+    def _cleanup_stale_locks(self) -> None:
+        """Remove lock files for sessions that no longer exist."""
+        self._lock_manager.cleanup_stale_locks(set(self._sessions.keys()))
+
+    def _get_used_ports(self) -> set[int]:
+        """Get ports in use by both in-memory and persisted sessions."""
+        in_memory_ports = {s.cdp_port for s in self._sessions.values() if s.cdp_port is not None}
+        disk_ports = self._persistence.read_used_ports(set(self._sessions.keys()))
+        return in_memory_ports | disk_ports
+
+    def with_session_lock(self, session_id: str, timeout: float | None = None) -> AbstractContextManager[None]:
+        """Context manager for file-based session locking.
+
+        Args:
+            session_id: Unique identifier for the session
+            timeout: Maximum time to wait for lock acquisition in seconds
+                    (default: SESSION_LOCK_TIMEOUT_SECONDS)
+
+        Yields:
+            None (lock is held during context)
+
+        Raises:
+            SessionNotFoundError: If session does not exist
+            SessionLockTimeout: If lock cannot be acquired within timeout
+        """
+
+        def check_session_exists(sid: str) -> None:
+            if sid not in self._sessions:
+                raise SessionNotFoundError(f"Session '{sid}' not found")
+
+        return self._lock_manager.with_lock(session_id, check_session_exists, timeout)
+
+    _VALID_SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+    @staticmethod
+    def _validate_session_id(session_id: str) -> None:
+        """Validate session_id to prevent path traversal attacks.
+
+        Args:
+            session_id: The session ID to validate
+
+        Raises:
+            ValueError: If session_id is invalid
+        """
+        if not session_id or not session_id.strip():
+            raise ValueError("Session ID must not be empty or whitespace-only")
+        if "\x00" in session_id:
+            raise ValueError("Session ID must not contain null bytes")
+        if ".." in session_id or "/" in session_id or "\\" in session_id:
+            raise ValueError("Session ID must not contain path separators or '..'")
+        if not SessionManager._VALID_SESSION_ID_PATTERN.match(session_id):
+            raise ValueError("Session ID must contain only alphanumeric characters, hyphens, underscores, or dots")
+
+    def _initialize_session_info(self, session_id: str) -> SessionInfo:
+        """Initialize session info and persist to disk.
+
+        Args:
+            session_id: Unique identifier for the session
+
+        Returns:
+            SessionInfo object in STARTING state
+        """
+        session_info = SessionInfo(
+            session_id=session_id,
+            state=SessionState.STARTING,
+            nova_act_instance=None,
+            created_at=datetime.now(),
+            last_used=datetime.now(),
+        )
+        self._sessions[session_id] = session_info
+        self._persistence.write_session_metadata(session_info)
+
+        # Create lock file
+        lock_path = self._lock_manager.get_lock_file_path(session_id)
+        lock_path.touch()
+
+        return session_info
+
+    def _handle_browser_setup_failure(self, session_info: SessionInfo, error: Exception, context: str) -> None:
+        """Handle browser setup failure by updating session state and persisting.
+
+        Args:
+            session_info: Session that failed
+            error: Exception that caused the failure
+            context: Context message describing what failed
+
+        Raises:
+            RuntimeError: Always raises with context and original error
+        """
+        session_info.state = SessionState.FAILED
+        session_info.error_message = str(error)
+        self._persistence.write_session_metadata(session_info)
+        raise RuntimeError(f"{context}: {error}") from error
+
+    def _launch_new_browser(
+        self,
+        session_info: SessionInfo,
+        headless: bool,
+        executable_path: str | None,
+        profile_path: str | None,
+        launch_args: list[str] | None = None,
+    ) -> None:
+        """Launch new Chrome browser instance.
+
+        Args:
+            session_info: Session to update with browser details
+            headless: Whether to launch in headless mode
+            executable_path: Optional custom browser executable
+            profile_path: Optional browser profile path
+            launch_args: Additional Chrome launch arguments
+
+        Raises:
+            RuntimeError: If launch fails
+        """
+        try:
+            launch = self._chrome_launcher.launch_chrome_with_cdp(
+                session_info.session_id, headless, executable_path, profile_path, launch_args
+            )
+            session_info.browser_pid = launch.process.pid
+            session_info.cdp_endpoint = launch.ws_url
+            session_info.cdp_port = launch.port
+            session_info.user_data_dir = str(launch.user_data_dir)
+        except Exception as e:
+            self._handle_browser_setup_failure(
+                session_info,
+                e,
+                f"Failed to launch Chrome for session '{session_info.session_id}'",
+            )
+
+    @staticmethod
+    def _is_system_chrome_data_dir(path: str) -> bool:
+        """Check if a path is or is inside Chrome's default user data directory.
+
+        Chrome blocks CDP when --user-data-dir points at its own default data
+        directory. This detects that case so we can rsync to a managed copy first.
+
+        Args:
+            path: Resolved filesystem path to check
+
+        Returns:
+            True if path is Chrome's default data dir or a subdirectory of it
+        """
+        if platform.system() != "Darwin":
+            return False
+        default_chrome_dir = os.path.expanduser("~/Library/Application Support/Google/Chrome")
+        try:
+            resolved = str(Path(path).resolve())
+            default_resolved = str(Path(default_chrome_dir).resolve())
+            return os.path.samefile(resolved, default_resolved) or resolved.startswith(default_resolved + os.sep)
+        except (OSError, ValueError):
+            return False
+
+    def _launch_with_rsynced_profile(self, session_info: SessionInfo, options: BrowserOptions) -> None:
+        """Rsync system Chrome profile to a managed directory and launch Chrome.
+
+        Used when --browser-profile-path points at Chrome's default data directory
+        (or a subdirectory like Default/). Chrome blocks CDP on its own default
+        data dir, so we rsync to a managed copy first — same approach as
+        --use-default-chrome.
+
+        Args:
+            session_info: Session to configure with browser details
+            options: Browser options with profile_path pointing at system Chrome
+
+        Raises:
+            RuntimeError: If rsync or launch fails
+        """
+        # Determine the profile subdirectory (e.g. "Default") if the user pointed
+        # at a profile subdir rather than the top-level Chrome data dir.
+        assert options.profile_path is not None, "profile_path required for system Chrome sync"
+        profile_dir = Path(options.profile_path).expanduser().resolve()
+        default_chrome_dir = Path(os.path.expanduser("~/Library/Application Support/Google/Chrome")).resolve()
+        profile_directory: str | None = None
+        if profile_dir != default_chrome_dir:
+            # User pointed at a subdirectory like Default/ or "Profile 1/"
+            profile_directory = str(profile_dir.relative_to(default_chrome_dir))
+
+        # Create managed working directory
+        working_dir_path = get_browser_cli_dir() / "chrome_profiles" / session_info.session_id
+        working_dir_path.mkdir(parents=True, exist_ok=True)
+        working_dir = str(working_dir_path)
+
+        # Rsync Chrome data to managed directory
+        try:
+            from nova_act import rsync_from_default_user_data  # noqa: PLC0415
+
+            rsync_from_default_user_data(working_dir)
+        except Exception as e:
+            self._handle_browser_setup_failure(
+                session_info,
+                e,
+                f"Failed to rsync Chrome profile for session '{session_info.session_id}'",
+            )
+
+        session_info.user_data_dir = working_dir
+
+        # Remove SingletonLock as safety net (rsync excludes Singleton* but belt-and-suspenders)
+        (Path(working_dir) / "SingletonLock").unlink(missing_ok=True)
+
+        # Launch Chrome with the rsynced copy
+        try:
+            chrome_path = options.executable_path or self._chrome_launcher.detect_chrome_path()
+            self._chrome_launcher._validate_browser_executable(chrome_path)
+            port = self._chrome_launcher.find_available_port()
+            user_data_dir = Path(working_dir)
+
+            launch_args = list(options.launch_args) if options.launch_args else []
+            if profile_directory:
+                launch_args.append(f"--profile-directory={profile_directory}")
+
+            args = self._chrome_launcher._build_chrome_arguments(
+                chrome_path, port, user_data_dir, options.headless, launch_args or None
+            )
+            process, ws_url = self._chrome_launcher._launch_and_connect(args, port)
+            session_info.browser_pid = process.pid
+            session_info.cdp_endpoint = ws_url
+            session_info.cdp_port = port
+        except Exception as e:
+            self._handle_browser_setup_failure(
+                session_info,
+                e,
+                f"Failed to launch Chrome for session '{session_info.session_id}'",
+            )
+
+    def _setup_browser(self, session_info: SessionInfo, options: BrowserOptions) -> None:
+        """Setup browser by launching a new Chrome instance or preparing for default Chrome.
+
+        Args:
+            session_info: Session to configure with browser details
+            options: Browser configuration options
+
+        Raises:
+            RuntimeError: If browser setup fails
+        """
+        if options.use_default_chrome:
+            self._setup_default_chrome(session_info, options)
+        elif options.profile_path and self._is_system_chrome_data_dir(
+            str(Path(options.profile_path).expanduser().resolve())
+        ):
+            self._launch_with_rsynced_profile(session_info, options)
+        else:
+            self._launch_new_browser(
+                session_info,
+                options.headless,
+                options.executable_path,
+                options.profile_path,
+                options.launch_args or None,
+            )
+
+    def _setup_default_chrome(self, session_info: SessionInfo, options: BrowserOptions) -> None:
+        """Rsync Chrome profile and prepare session for NovaAct's default Chrome flow.
+
+        Args:
+            session_info: Session to configure
+            options: Browser options with use_default_chrome=True
+
+        Raises:
+            RuntimeError: If not on macOS or rsync fails
+        """
+        if platform.system() != "Darwin":
+            self._handle_browser_setup_failure(
+                session_info,
+                RuntimeError("--use-default-chrome is only supported on macOS"),
+                "Platform check failed",
+            )
+
+        # Determine working directory
+        if options.user_data_dir:
+            working_dir = options.user_data_dir
+        else:
+            profile_dir = get_browser_cli_dir() / "chrome_profiles" / session_info.session_id
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            working_dir = str(profile_dir)
+
+        try:
+            from nova_act import rsync_from_default_user_data  # noqa: PLC0415
+
+            rsync_from_default_user_data(working_dir)
+        except Exception as e:
+            self._handle_browser_setup_failure(
+                session_info,
+                e,
+                f"Failed to rsync Chrome profile for session '{session_info.session_id}'",
+            )
+
+        session_info.user_data_dir = working_dir
+
+        # Remove SingletonLock that may have been rsynced from the source Chrome profile.
+        # rsync_from_default_user_data excludes Singleton* but this is a safety net.
+        lock_file = Path(working_dir) / "SingletonLock"
+        lock_file.unlink(missing_ok=True)
+
+        # Launch Chrome using the rsynced user data directory directly.
+        # We bypass _launch_new_browser because _resolve_user_data_directory expects
+        # a profile dir (with Preferences at root), but working_dir is a full Chrome
+        # user data dir (Preferences lives in Default/ subdirectory).
+        try:
+            chrome_path = options.executable_path or self._chrome_launcher.detect_chrome_path()
+            self._chrome_launcher._validate_browser_executable(chrome_path)
+            port = self._chrome_launcher.find_available_port()
+            user_data_dir = Path(working_dir)
+            args = self._chrome_launcher._build_chrome_arguments(
+                chrome_path, port, user_data_dir, options.headless, options.launch_args or None
+            )
+            process, ws_url = self._chrome_launcher._launch_and_connect(args, port)
+            session_info.browser_pid = process.pid
+            session_info.cdp_endpoint = ws_url
+            session_info.cdp_port = port
+        except Exception as e:
+            self._handle_browser_setup_failure(
+                session_info,
+                e,
+                f"Failed to launch Chrome for session '{session_info.session_id}'",
+            )
+
+    def _count_active_sessions(self) -> int:
+        """Count sessions in active states (STARTING or STARTED)."""
+        self._load_existing_sessions()
+        return sum(1 for s in self._sessions.values() if s.state in (SessionState.STARTING, SessionState.STARTED))
+
+    def _cleanup_failed_session(self, session_id: str, session_info: SessionInfo) -> None:
+        """Terminate browser, remove metadata file, remove lock, and delete from memory.
+
+        Args:
+            session_id: ID of the failed session
+            session_info: Session info for the failed session
+        """
+        self._chrome_terminator.terminate(session_info.browser_pid)
+        session_file = self._persistence.get_session_file_path(session_id)
+        session_file.unlink(missing_ok=True)
+        self._lock_manager.remove_lock(session_id)
+        self._sessions.pop(session_id, None)
+
+    def create_session(
+        self,
+        session_id: str,
+        starting_page: str | None = None,
+        browser_options: BrowserOptions | None = None,
+        max_sessions: int | None = None,
+    ) -> SessionInfo:
+        """Create a new Nova Act session with CDP-based browser.
+
+        Args:
+            session_id: Unique identifier for the session
+            starting_page: Optional URL to navigate to when starting the session
+            browser_options: Browser configuration (headless, CDP endpoint, etc.)
+            max_sessions: Maximum number of active sessions allowed
+                (default: DefaultBrowserConfig.DEFAULT_MAX_ACTIVE_SESSIONS)
+
+        Returns:
+            SessionInfo object with session details
+
+        Raises:
+            ValueError: If session_id already exists
+            SessionLimitReached: If max active sessions limit is reached
+            RuntimeError: If Chrome launch or NovaAct.start() fails
+        """
+        # Auto-prune stale sessions to prevent resource accumulation
+        self.prune_sessions(ignore_ttl=False, dry_run=False)
+
+        if session_id in self._sessions:
+            existing = self._sessions[session_id]
+            if existing.state == SessionState.FAILED:
+                self._cleanup_failed_session(session_id, existing)
+            else:
+                raise ValueError(f"Session '{session_id}' already exists")
+
+        limit = max_sessions if max_sessions is not None else DefaultBrowserConfig.DEFAULT_MAX_ACTIVE_SESSIONS
+        active_count = self._count_active_sessions()
+        if active_count >= limit:
+            raise SessionLimitReached(
+                f"Maximum active sessions ({limit}) reached. "
+                f"Close existing sessions with 'act browser session close <id>' or "
+                f"'act browser session close-all', or increase limit with --max-sessions."
+            )
+
+        self._validate_session_id(session_id)
+        options = browser_options or BrowserOptions()
+        session_info = self._initialize_session_info(session_id)
+        session_info.browser_options_meta = {
+            "headless": options.headless,
+            "headed": options.headed,
+            "executable_path": options.executable_path,
+            "profile_path": options.profile_path,
+            "ignore_https_errors": options.ignore_https_errors,
+            "launch_args": options.launch_args,
+            "use_default_chrome": options.use_default_chrome,
+            "user_data_dir": options.user_data_dir,
+            "browser_source": "local",
+        }
+        if options.auth_config:
+            session_info.auth_config = options.auth_config
+        self._setup_browser(session_info, options)
+        try:
+            self._nova_act_connector.connect_to_session(
+                session_info,
+                starting_page,
+                options.nova_args,
+                auth_config=options.auth_config,
+            )
+            self._persistence.write_session_metadata(session_info)
+        except BaseException:
+            # Safety net: if connect_to_session raises anything not caught internally
+            # (e.g. KeyboardInterrupt, SystemExit), ensure Chrome doesn't leak.
+            if session_info.browser_pid and session_info.state != SessionState.FAILED:
+                self._chrome_terminator.terminate(session_info.browser_pid)
+                session_info.state = SessionState.FAILED
+                self._persistence.write_session_metadata(session_info)
+            raise
+        return session_info
+
+    def _validate_browser_running(self, session_info: SessionInfo) -> None:
+        """Validate that browser process is still running.
+
+        Args:
+            session_info: Session to validate
+
+        Raises:
+            BrowserProcessDead: If browser process is dead
+        """
+        if session_info.browser_pid and not is_process_running(session_info.browser_pid):
+            raise BrowserProcessDead(
+                f"Browser process {session_info.browser_pid} is no longer running. "
+                f"Close this session and create a new one: "
+                f"act browser session close {session_info.session_id} && "
+                f"act browser session create <url> --session-id {session_info.session_id}"
+            )
+
+    def get_session(self, session_id: str, auth_config: "AuthConfig | None" = None) -> SessionInfo:
+        """Retrieve an existing session by ID, reconnecting if needed.
+
+        Args:
+            session_id: Unique identifier for the session
+            auth_config: Authentication configuration for reconnection (overrides stored config)
+
+        Returns:
+            SessionInfo object for the session
+
+        Raises:
+            SessionNotFoundError: If session_id does not exist
+            BrowserProcessDead: If browser process is dead
+            RuntimeError: If reconnection fails
+        """
+        if session_id not in self._sessions:
+            try:
+                session_info = self._persistence.load_session(session_id)
+                self._sessions[session_id] = session_info
+            except (FileNotFoundError, json.JSONDecodeError, KeyError, ValueError):
+                raise SessionNotFoundError(f"Session '{session_id}' not found")
+
+        session_info = self._sessions[session_id]
+
+        if session_info.cdp_endpoint and not session_info.nova_act_instance:
+            self._validate_browser_running(session_info)
+            effective_auth = auth_config or session_info.auth_config
+            self._nova_act_connector.reconnect_to_session(session_info, auth_config=effective_auth)
+            self._persistence.write_session_metadata(session_info)
+
+        return session_info
+
+    def session_exists(self, session_id: str) -> bool:
+        """Check if a session exists without reconnecting or modifying state."""
+        if session_id in self._sessions:
+            return True
+        return self._persistence.get_session_file_path(session_id).exists()
+
+    def save_session_metadata(self, session_info: SessionInfo) -> None:
+        """Persist current session metadata to disk.
+
+        Args:
+            session_info: Session to persist.
+        """
+        self._persistence.write_session_metadata(session_info)
+
+    def _warn_orphaned_sessions(self, sessions: list[SessionInfo]) -> None:
+        """Log warnings for orphaned sessions (browser process no longer running)."""
+        orphaned_sessions = [s for s in sessions if s.is_orphaned]
+        if not orphaned_sessions:
+            return
+        orphan_details = [f"  • Session '{s.session_id}' (PID: {s.browser_pid})" for s in orphaned_sessions]
+        cleanup_lines = [f"  act browser session close --force {s.session_id}" for s in orphaned_sessions]
+        logger.warning(
+            "Orphaned browser sessions detected!\n"
+            "These sessions have browser processes that are no longer running:\n\n%s\n\n"
+            "To clean up, run:\n%s",
+            "\n".join(orphan_details),
+            "\n".join(cleanup_lines),
+        )
+
+    def list_sessions(self) -> list[SessionInfo]:
+        """List all sessions (active and inactive).
+
+        Loads persisted sessions from disk and checks for orphaned sessions.
+
+        Returns:
+            List of SessionInfo objects for all sessions
+        """
+        self._load_existing_sessions()
+        self._cleanup_stale_locks()
+
+        sessions = list(self._sessions.values())
+        self._warn_orphaned_sessions(sessions)
+        return sessions
+
+    def close_session(self, session_id: str, force: bool = False) -> None:
+        """Close an existing Nova Act session and terminate Chrome browser.
+
+        Args:
+            session_id: Unique identifier for the session
+            force: If True, skip NovaAct.stop() and remove session files immediately
+
+        Raises:
+            SessionNotFoundError: If session_id does not exist
+            RuntimeError: If NovaAct.stop() fails (only when force=False)
+        """
+        session_info = self._session_closer.load_session_for_close(session_id, force, self._sessions, self.get_session)
+
+        if force:
+            self._session_closer.force_close(session_id, session_info, self._sessions)
+            return
+
+        if session_info.state == SessionState.FAILED:
+            self._session_closer.cleanup_failed_session(session_id)
+            return
+
+        self._session_closer.normal_close(session_id, session_info, self._sessions)
+
+    def prune_sessions(self, ignore_ttl: bool = False, dry_run: bool = False) -> list[PruneResult]:
+        """Remove stale or inactive sessions and their Chrome profile directories.
+
+        Args:
+            ignore_ttl: If True, prune all non-active sessions regardless of TTL
+            dry_run: If True, return what would be pruned without deleting
+
+        Returns:
+            List of PruneResult for each pruned session.
+        """
+        self._load_existing_sessions()
+        return self._session_pruner.prune(
+            self._sessions,
+            ignore_ttl=ignore_ttl,
+            dry_run=dry_run,
+        )

--- a/src/nova_act/cli/browser/services/session/models.py
+++ b/src/nova_act/cli/browser/services/session/models.py
@@ -1,0 +1,178 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session data models for Nova Act CLI.
+
+This module defines the core data structures for session management.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import psutil
+
+from nova_act.cli.browser.services.browser_config import DefaultBrowserConfig
+from nova_act.cli.browser.utils.auth import AuthConfig
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+
+class BrowserSource(Enum):
+    """Source of the browser instance.
+
+    Attributes:
+        LOCAL: Browser launched locally via ChromeLauncher
+    """
+
+    LOCAL = "local"
+
+
+class SessionState(Enum):
+    """Lifecycle states for a managed session.
+
+    Attributes:
+        STARTING: Session is being initialized
+        STARTED: Session is active and ready for commands
+        STOPPING: Session is being terminated
+        STOPPED: Session has been cleanly terminated
+        FAILED: Session encountered an error during start or operation
+    """
+
+    STARTING = "starting"
+    STARTED = "started"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass
+class BrowserOptions:
+    """Browser configuration options for session creation.
+
+    Attributes:
+        headless: Launch browser in headless mode (no visible UI)
+        headed: Launch browser in headed mode (visible UI) - overrides headless
+        executable_path: Path to custom Chromium-based browser executable
+        profile_path: Path to browser profile directory for persistent sessions
+        nova_args: Additional arguments to pass to NovaAct constructor
+    """
+
+    headless: bool = True
+    headed: bool = False
+    executable_path: str | None = None
+    profile_path: str | None = None
+    ignore_https_errors: bool = True
+    nova_args: dict[str, object] = field(default_factory=dict)
+    launch_args: list[str] = field(default_factory=list)
+    auth_config: AuthConfig | None = None
+    use_default_chrome: bool = False
+    user_data_dir: str | None = None
+    cdp_endpoint_url: str | None = None
+
+
+@dataclass
+class SessionInfo:
+    """Information about a Nova Act session.
+
+    Attributes:
+        session_id: Unique identifier for the session
+        state: Current lifecycle state of the session
+        nova_act_instance: The NovaAct client instance (None if not started)
+        created_at: Timestamp when session was created
+        browser_pid: Process ID of the browser (None if not started)
+        user_data_dir: Path to browser user data directory (None if not started)
+        last_used: Timestamp when session was last used
+        cdp_endpoint: Chrome DevTools Protocol WebSocket URL (None if not using CDP)
+        cdp_port: Port number for CDP connection (None if not using CDP)
+        error_message: Error message if session failed
+        browser_options_meta: Serialized browser options for persistence
+        auth_config: Authentication configuration used for this session
+    """
+
+    session_id: str
+    state: SessionState
+    nova_act_instance: NovaAct | None
+    created_at: datetime
+    browser_pid: int | None = None
+    user_data_dir: str | None = None
+    last_used: datetime | None = None
+    cdp_endpoint: str | None = None
+    cdp_port: int | None = None
+    error_message: str | None = None
+    browser_options_meta: dict[str, object] = field(default_factory=dict)
+    auth_config: AuthConfig | None = None
+    active_tab_index: int = 0
+
+    @property
+    def is_orphaned(self) -> bool:
+        """Check if session is orphaned (browser process died but session marked as STARTED).
+
+        Returns:
+            True if session is orphaned, False otherwise
+        """
+        if self.state != SessionState.STARTED:
+            return False
+
+        if self.browser_pid is None:
+            return False
+
+        try:
+            process = psutil.Process(self.browser_pid)
+            return not process.is_running()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            return True
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize session info to a dictionary suitable for JSON persistence.
+
+        Returns:
+            Dictionary with all serializable session fields.
+            Excludes nova_act_instance. Formats datetimes as ISO strings
+            and state as its string value.
+        """
+        metadata: dict[str, object] = {}
+        if self.error_message:
+            metadata["error_message"] = self.error_message
+        if self.browser_options_meta:
+            metadata["browser_options"] = self.browser_options_meta
+        return {
+            "session_id": self.session_id,
+            "state": self.state.value,
+            "created_at": self.created_at.isoformat(),
+            "browser_pid": self.browser_pid,
+            "user_data_dir": self.user_data_dir,
+            "last_used": self.last_used.isoformat() if self.last_used else None,
+            "cdp_endpoint": self.cdp_endpoint,
+            "cdp_port": self.cdp_port,
+            "browser_source": BrowserSource.LOCAL.value,
+            "active_tab_index": self.active_tab_index,
+            "metadata": metadata,
+        }
+
+    @property
+    def is_stale(self) -> bool:
+        """Check if session is stale (no activity within TTL period).
+
+        A session is stale if its last activity timestamp is older than
+        SESSION_STALE_TTL_HOURS. Uses last_used if available, otherwise created_at.
+
+        Returns:
+            True if session is stale, False otherwise
+        """
+        reference_time = self.last_used or self.created_at
+        return datetime.now() - reference_time > timedelta(hours=DefaultBrowserConfig.SESSION_STALE_TTL_HOURS)

--- a/src/nova_act/cli/browser/services/session/persistence.py
+++ b/src/nova_act/cli/browser/services/session/persistence.py
@@ -1,0 +1,293 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session persistence module for managing session metadata storage.
+
+This module handles all file-based session metadata operations including:
+- Creating and managing session directory
+- Reading/writing session metadata to JSON files
+- Loading existing sessions from disk on startup
+"""
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import TypedDict
+
+from nova_act.cli.browser.services.session.cdp_endpoint_manager import (
+    CdpEndpointManager,
+)
+from nova_act.cli.browser.services.session.models import (
+    SessionInfo,
+    SessionState,
+)
+from nova_act.cli.core.process import is_process_running
+
+
+class _MetadataFields(TypedDict):
+    """Typed fields extracted from session metadata for SessionInfo construction."""
+
+    last_used: str | None
+    user_data_dir: str | None
+    cdp_port: int | None
+    active_tab_index: int
+    error_message: str | None
+    browser_options_meta: dict[str, object]
+
+
+logger = logging.getLogger(__name__)
+
+# Secure directory permissions: owner read/write/execute only
+SESSION_DIR_PERMISSIONS = 0o700
+
+
+class SessionPersistence:
+    """Manages file-based session metadata storage and retrieval."""
+
+    def __init__(self, session_dir: str):
+        """Initialize session persistence manager.
+
+        Args:
+            session_dir: Directory path for storing session metadata files
+        """
+        self.session_dir = session_dir
+        self._ensure_session_directory()
+
+    def _ensure_session_directory(self) -> None:
+        """Create session directory if it doesn't exist with secure permissions."""
+        session_path = Path(self.session_dir)
+        if not session_path.exists():
+            session_path.mkdir(parents=True, mode=SESSION_DIR_PERMISSIONS, exist_ok=True)
+        else:
+            # Ensure correct permissions on existing directory
+            os.chmod(self.session_dir, SESSION_DIR_PERMISSIONS)
+
+    def get_session_file_path(self, session_id: str) -> Path:
+        """Get path to session metadata file.
+
+        Args:
+            session_id: Unique identifier for the session
+
+        Returns:
+            Path to session JSON file
+        """
+        return Path(self.session_dir) / f"{session_id}.json"
+
+    def write_session_metadata(self, session_info: SessionInfo) -> None:
+        """Write session metadata to JSON file.
+
+        Args:
+            session_info: SessionInfo object to serialize
+        """
+        metadata = session_info.to_dict()
+
+        file_path = self.get_session_file_path(session_info.session_id)
+        fd, tmp_path = tempfile.mkstemp(dir=str(file_path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, indent=2)
+            os.replace(tmp_path, file_path)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
+
+    def read_session_metadata(self, session_id: str) -> dict[str, object]:
+        """Read session metadata from JSON file.
+
+        Args:
+            session_id: Unique identifier for the session
+
+        Returns:
+            Dictionary containing session metadata
+
+        Raises:
+            FileNotFoundError: If session file doesn't exist
+            json.JSONDecodeError: If session file is corrupted
+        """
+        file_path = self.get_session_file_path(session_id)
+        with open(file_path, "r", encoding="utf-8") as f:
+            result: dict[str, object] = json.load(f)
+            return result
+
+    def load_session(self, session_id: str) -> SessionInfo:
+        """Load a single session from disk by ID.
+
+        Args:
+            session_id: Unique identifier for the session
+
+        Returns:
+            SessionInfo object with nova_act_instance=None (state determined by PID liveness)
+
+        Raises:
+            FileNotFoundError: If session file doesn't exist
+            json.JSONDecodeError: If session file is corrupted
+            KeyError: If required metadata fields are missing
+            ValueError: If metadata values are invalid
+        """
+        metadata = self.read_session_metadata(session_id)
+        return self._reconstruct_session_from_metadata(metadata)
+
+    def _reconstruct_session_from_metadata(self, metadata: dict[str, object]) -> SessionInfo:
+        """Reconstruct SessionInfo from metadata dictionary.
+
+        Determines session state by checking if the browser process is still running
+        and whether the CDP endpoint is responsive.
+
+        Args:
+            metadata: Dictionary containing session metadata
+
+        Returns:
+            SessionInfo object with nova_act_instance=None
+        """
+        raw_pid = metadata.get("browser_pid")
+        browser_pid = int(raw_pid) if isinstance(raw_pid, (int, float)) else None
+        cdp_endpoint_raw = metadata.get("cdp_endpoint")
+
+        # Determine state
+        state = self._determine_session_state(browser_pid, cdp_endpoint_raw)
+
+        # Extract remaining fields
+        fields = self._extract_metadata_fields(metadata)
+
+        return SessionInfo(
+            session_id=str(metadata["session_id"]),
+            state=state,
+            nova_act_instance=None,
+            created_at=datetime.fromisoformat(str(metadata["created_at"])),
+            browser_pid=browser_pid,
+            user_data_dir=fields["user_data_dir"],
+            last_used=datetime.fromisoformat(fields["last_used"]) if fields["last_used"] else None,
+            cdp_endpoint=str(cdp_endpoint_raw) if cdp_endpoint_raw is not None else None,
+            cdp_port=fields["cdp_port"],
+            error_message=fields["error_message"],
+            browser_options_meta=fields["browser_options_meta"],
+            auth_config=None,  # Auth resolved fresh each invocation (GAP-5)
+            active_tab_index=fields["active_tab_index"],
+        )
+
+    @staticmethod
+    def _determine_session_state(
+        browser_pid: int | None,
+        cdp_endpoint_raw: object,
+    ) -> SessionState:
+        """Determine session state from browser liveness signals.
+
+        Checks PID liveness and CDP endpoint responsiveness.
+        """
+        if browser_pid is None or not is_process_running(browser_pid):
+            return SessionState.STOPPED
+
+        if cdp_endpoint_raw is not None:
+            try:
+                CdpEndpointManager().validate_cdp_endpoint(str(cdp_endpoint_raw))
+                return SessionState.STARTED
+            except RuntimeError:
+                logger.warning(
+                    "Session has live PID %d but CDP endpoint '%s' is unresponsive; marking STOPPED",
+                    browser_pid,
+                    cdp_endpoint_raw,
+                )
+                return SessionState.STOPPED
+
+        return SessionState.STARTED
+
+    @staticmethod
+    def _extract_metadata_fields(metadata: dict[str, object]) -> _MetadataFields:
+        """Extract and normalize optional metadata fields.
+
+        Returns:
+            Dictionary with normalized field values ready for SessionInfo construction.
+        """
+        last_used_raw = metadata.get("last_used")
+        user_data_dir_raw = metadata.get("user_data_dir")
+        cdp_port_raw = metadata.get("cdp_port")
+        active_tab_index_raw = metadata.get("active_tab_index", 0)
+
+        meta_dict = metadata.get("metadata", {})
+        meta_dict = meta_dict if isinstance(meta_dict, dict) else {}
+        error_message_raw = meta_dict.get("error_message")
+        browser_options_raw = meta_dict.get("browser_options")
+
+        return {
+            "last_used": str(last_used_raw) if last_used_raw else None,
+            "user_data_dir": str(user_data_dir_raw) if user_data_dir_raw is not None else None,
+            "cdp_port": int(cdp_port_raw) if isinstance(cdp_port_raw, (int, float)) else None,
+            "active_tab_index": int(active_tab_index_raw) if isinstance(active_tab_index_raw, (int, float)) else 0,
+            "error_message": str(error_message_raw) if error_message_raw else None,
+            "browser_options_meta": browser_options_raw if isinstance(browser_options_raw, dict) else {},
+        }
+
+    def read_used_ports(self, exclude_ids: set[str]) -> set[int]:
+        """Read CDP port numbers from session metadata files without loading full sessions.
+
+        Args:
+            exclude_ids: Session IDs to skip (already in memory)
+
+        Returns:
+            Set of port numbers in use by persisted sessions
+        """
+        session_dir = Path(self.session_dir)
+        if not session_dir.exists():
+            return set()
+
+        ports: set[int] = set()
+        for session_file in session_dir.glob("*.json"):
+            if session_file.stem in exclude_ids:
+                continue
+            try:
+                with open(session_file, "r", encoding="utf-8") as f:
+                    metadata = json.load(f)
+                    if port := metadata.get("cdp_port"):
+                        ports.add(port)
+            except (json.JSONDecodeError, OSError):
+                continue
+        return ports
+
+    def load_existing_sessions(self, existing_session_ids: set[str]) -> dict[str, SessionInfo]:
+        """Load existing sessions from disk.
+
+        Discovers session metadata files in session_dir and reconstructs
+        SessionInfo objects. Handles corrupted files gracefully by logging
+        warnings and skipping them.
+
+        Args:
+            existing_session_ids: Set of session IDs already in memory (to skip)
+
+        Returns:
+            Dictionary mapping session_id to SessionInfo for loaded sessions
+
+        Note: Only loads sessions that don't already exist in memory to avoid
+        overwriting active sessions with nova_act_instance=None.
+
+        Session state is determined by checking if the browser PID is still alive.
+        """
+        session_dir = Path(self.session_dir)
+        if not session_dir.exists():
+            return {}
+
+        session_files = [f for f in session_dir.glob("*.json") if f.stem not in existing_session_ids]
+
+        loaded_sessions: dict[str, SessionInfo] = {}
+        for session_file in session_files:
+            session_id = session_file.stem
+            try:
+                metadata = self.read_session_metadata(session_id)
+                session_info = self._reconstruct_session_from_metadata(metadata)
+                loaded_sessions[session_info.session_id] = session_info
+            except (FileNotFoundError, json.JSONDecodeError, KeyError, ValueError) as e:
+                logger.warning("Failed to load session '%s': %s", session_id, e)
+
+        return loaded_sessions

--- a/src/nova_act/cli/browser/services/session/pruner.py
+++ b/src/nova_act/cli/browser/services/session/pruner.py
@@ -1,0 +1,135 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session pruning logic extracted from SessionManager."""
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import psutil
+
+from nova_act.cli.browser.services.session.chrome_terminator import ChromeTerminator
+from nova_act.cli.browser.services.session.locking import SessionLockManager
+from nova_act.cli.browser.services.session.models import SessionInfo, SessionState
+from nova_act.cli.browser.services.session.persistence import SessionPersistence
+from nova_act.cli.browser.utils.log_capture import cleanup_session_logs
+from nova_act.cli.core.config import get_cli_config_dir
+
+_CLI_CONFIG_DIR = get_cli_config_dir()
+
+
+def _has_dead_pid(session: SessionInfo) -> bool:
+    """Check if a non-active session's browser PID is dead.
+
+    Returns True if the session has a browser PID that is no longer running,
+    indicating the session is safe to prune regardless of TTL.
+    """
+    if session.browser_pid is None:
+        return True  # No PID means browser is gone — safe to prune
+    try:
+        process = psutil.Process(session.browser_pid)
+        return not process.is_running()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return True
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    """Result of pruning a single session.
+
+    Attributes:
+        session_id: ID of the pruned session.
+        user_data_dir: Path to the Chrome user data directory (if any).
+    """
+
+    session_id: str
+    user_data_dir: str | None = None
+
+
+def _should_delete_user_data_dir(session_info: SessionInfo) -> bool:
+    """Determine if a session's user_data_dir is safe to delete.
+
+    Returns True only when:
+    - The session has a user_data_dir
+    - It is NOT the user's explicitly provided profile path
+    - It resides within the CLI config directory
+    """
+    if not session_info.user_data_dir:
+        return False
+    raw_profile = session_info.browser_options_meta.get("profile_path") if session_info.browser_options_meta else None
+    if (
+        raw_profile
+        and isinstance(raw_profile, str)
+        and str(Path(raw_profile).resolve()) == str(Path(session_info.user_data_dir).resolve())
+    ):
+        return False
+    try:
+        Path(session_info.user_data_dir).resolve().relative_to(_CLI_CONFIG_DIR.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+class SessionPruner:
+    """Prunes stale or inactive sessions and their Chrome profile directories."""
+
+    def __init__(
+        self,
+        persistence: SessionPersistence,
+        chrome_terminator: ChromeTerminator,
+        lock_manager: SessionLockManager,
+    ) -> None:
+        self._persistence = persistence
+        self._chrome_terminator = chrome_terminator
+        self._lock_manager = lock_manager
+
+    def prune(
+        self,
+        sessions: dict[str, SessionInfo],
+        ignore_ttl: bool = False,
+        dry_run: bool = False,
+    ) -> list[PruneResult]:
+        """Remove stale or inactive sessions and their Chrome profile directories.
+
+        Args:
+            sessions: In-memory session dictionary (mutated: pruned entries removed)
+            ignore_ttl: If True, prune all non-active sessions regardless of TTL
+            dry_run: If True, return what would be pruned without deleting
+
+        Returns:
+            List of PruneResult for each pruned session.
+        """
+        active_states = (SessionState.STARTING, SessionState.STARTED)
+        pruneable = [
+            s
+            for s in sessions.values()
+            if s.state not in active_states and (ignore_ttl or s.is_stale or _has_dead_pid(s))
+        ]
+
+        results: list[PruneResult] = []
+        for session_info in pruneable:
+            results.append(PruneResult(session_id=session_info.session_id, user_data_dir=session_info.user_data_dir))
+            if dry_run:
+                continue
+            self._chrome_terminator.terminate(session_info.browser_pid)
+            if _should_delete_user_data_dir(session_info):
+                assert session_info.user_data_dir is not None  # guaranteed by _should_delete_user_data_dir
+                shutil.rmtree(session_info.user_data_dir, ignore_errors=True)
+            session_file = self._persistence.get_session_file_path(session_info.session_id)
+            session_file.unlink(missing_ok=True)
+            cleanup_session_logs(session_info.session_id)
+            sessions.pop(session_info.session_id, None)
+            self._lock_manager.remove_lock(session_info.session_id)
+
+        return results

--- a/src/nova_act/cli/browser/services/session_recorder.py
+++ b/src/nova_act/cli/browser/services/session_recorder.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session recorder — automatic manifest of every command executed in a session."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+from typing import TypedDict
+
+from typing_extensions import NotRequired
+
+from nova_act.cli.browser.utils.log_capture import get_log_dir
+
+
+class CommandEntry(TypedDict, total=False):
+    """A single command recorded in the session manifest."""
+
+    command: str
+    type: str
+    args: dict[str, object]
+    timestamp: str
+    duration_ms: float
+    result_summary: dict[str, object]
+    screenshots: dict[str, str | None]
+    log_file: str
+    steps_file: str
+    steps_summary: object
+    screenshots_base64: dict[str, str]
+    result: dict[str, object]
+
+
+class SessionManifest(TypedDict):
+    """Top-level session recording manifest."""
+
+    session_id: str
+    started_at: str
+    commands: list[CommandEntry]
+    last_updated: NotRequired[str]
+
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = "recording.json"
+
+
+class SessionRecorder:
+    """Records every command invocation in a session as a JSON manifest.
+
+    The manifest is written to the session's log directory and updated
+    after each command completes. No explicit start/stop — recording is
+    always active.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self._log_dir = get_log_dir(session_id)
+        self._manifest_path = self._log_dir / MANIFEST_FILENAME
+        self._manifest: SessionManifest = self._load_or_create()
+
+    def _load_or_create(self) -> SessionManifest:
+        """Load existing manifest or create a new one."""
+        if self._manifest_path.exists():
+            try:
+                data: SessionManifest = json.loads(self._manifest_path.read_text())
+                return data
+            except (json.JSONDecodeError, OSError):
+                logger.debug("Corrupt manifest at %s, creating new", self._manifest_path)
+        return SessionManifest(
+            session_id=self.session_id,
+            started_at=datetime.now().isoformat(),
+            commands=[],
+        )
+
+    def record_step(
+        self,
+        command_name: str,
+        args: dict[str, object] | None = None,
+        started_at: datetime | None = None,
+        duration_ms: float | None = None,
+        result_summary: dict[str, object] | None = None,
+        screenshots: dict[str, str | None] | None = None,
+        log_file: str | None = None,
+        steps_file: str | None = None,
+    ) -> None:
+        """Append a command entry to the manifest and persist to disk."""
+        entry: CommandEntry = {
+            "command": command_name,
+            "args": args or {},
+            "timestamp": (started_at or datetime.now()).isoformat(),
+        }
+        if duration_ms is not None:
+            entry["duration_ms"] = round(duration_ms, 1)
+        if result_summary:
+            entry["result_summary"] = result_summary
+        if screenshots:
+            entry["screenshots"] = {k: v for k, v in screenshots.items() if v}
+        if log_file:
+            entry["log_file"] = log_file
+        if steps_file:
+            entry["steps_file"] = steps_file
+
+        self._manifest["commands"].append(entry)
+        self._manifest["last_updated"] = datetime.now().isoformat()
+        self._persist()
+
+    def get_manifest(self) -> SessionManifest:
+        """Return the current manifest."""
+        return self._manifest
+
+    def get_commands(self, limit: int | None = None) -> list[CommandEntry]:
+        """Return recorded commands, optionally limited to last N."""
+        commands = self._manifest["commands"]
+        if limit is not None and limit > 0:
+            return commands[-limit:]
+        return commands
+
+    def _persist(self) -> None:
+        """Atomically write manifest to disk."""
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(self._log_dir), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._manifest, f, indent=2)
+            os.replace(tmp_path, str(self._manifest_path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+
+# Module-level registry: session_id → SessionRecorder
+_recorder_registry: dict[str, SessionRecorder] = {}
+
+
+def get_recorder(session_id: str) -> SessionRecorder:
+    """Get or create a SessionRecorder for the given session."""
+    if session_id not in _recorder_registry:
+        _recorder_registry[session_id] = SessionRecorder(session_id)
+    return _recorder_registry[session_id]

--- a/src/nova_act/cli/browser/services/step_tracking.py
+++ b/src/nova_act/cli/browser/services/step_tracking.py
@@ -1,0 +1,245 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Step tracking — monkey-patch NovaAct for per-step a11y snapshots + steps summary writer."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+
+import yaml
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+    from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement
+
+
+# ---------------------------------------------------------------------------
+# TypedDicts for the trajectory JSON written by the SDK's run_info_compiler.
+# The SDK has no exported types for this format, so we define them CLI-side.
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryCall(TypedDict):
+    """A single call within a step's program."""
+
+    name: str
+    kwargs: dict[str, object]
+
+
+class TrajectoryProgram(TypedDict):
+    """The program executed during a single step."""
+
+    calls: list[TrajectoryCall]
+
+
+class _TrajectoryStepRequired(TypedDict):
+    """Required fields for a trajectory step."""
+
+    program: TrajectoryProgram
+
+
+class TrajectoryStep(_TrajectoryStepRequired, total=False):
+    """A single step in the trajectory. ``active_url`` is optional in the JSON."""
+
+    active_url: str
+
+
+class TrajectoryMetadata(TypedDict, total=False):
+    """Top-level metadata block in the trajectory JSON."""
+
+    time_worked_s: float
+
+
+class TrajectoryData(TypedDict, total=False):
+    """Top-level trajectory JSON structure."""
+
+    steps: list[TrajectoryStep]
+    metadata: TrajectoryMetadata
+
+
+logger = logging.getLogger(__name__)
+
+
+def patch_nova_act_for_step_snapshots(nova_act: NovaAct, snapshots_out: list[list[SnapshotElement]]) -> None:
+    """Monkey-patch NovaAct to capture a11y tree between act() steps.
+
+    NOTE: This SHOULD be a proper SDK hook (e.g. on_step_complete callback).
+    Monkey-patching is a stopgap until the SDK exposes a first-class extension point.
+
+    Patches the dispatcher's program runner to capture an accessibility snapshot
+    after each program execution (i.e. after each step). Snapshots accumulate in
+    ``snapshots_out`` (passed by reference). Snapshot failure never breaks act().
+    """
+    try:
+        runner = nova_act.dispatcher._program_runner
+    except AttributeError:
+        logger.debug("Cannot patch NovaAct — dispatcher or _program_runner not found")
+        return
+
+    original_run = runner.run
+
+    def _patched_run(program, *args, **kwargs):  # type: ignore[no-untyped-def]
+        result = original_run(program, *args, **kwargs)
+        try:
+            from nova_act.cli.browser.services.intent_resolution.snapshot import (
+                flatten_snapshot,
+            )
+
+            tree = nova_act.page.accessibility.snapshot()
+            snapshots_out.append(flatten_snapshot(tree))
+        except Exception:
+            logger.debug("Step snapshot capture failed", exc_info=True)
+        return result
+
+    runner.run = _patched_run  # type: ignore[method-assign]
+
+
+def write_steps_summary(
+    trajectory_dir: Path,
+    command_name: str,
+    snapshots: list[list[SnapshotElement]],
+    log_dir: Path,
+) -> dict[str, object] | None:
+    """Parse trajectory JSON, merge with monkey-patch snapshots, write steps summary.
+
+    Args:
+        trajectory_dir: Directory containing SDK trajectory files.
+        command_name: Name of the command (unused, kept for API compat).
+        snapshots: Per-step a11y snapshots from monkey-patch.
+        log_dir: Per-command subdirectory to write steps.yaml into.
+
+    Returns ``{"steps_taken": N, "time_worked_s": T, "steps_path": path}`` or None on failure.
+    """
+    try:
+        trajectory_file = _find_latest_trajectory(trajectory_dir)
+        if trajectory_file is None:
+            logger.debug("No trajectory file found in %s", trajectory_dir)
+            return None
+
+        trajectory = json.loads(trajectory_file.read_text())
+        steps_data = _extract_steps(trajectory)
+        step_transitions = _compute_step_transitions(snapshots)
+
+        # Merge transitions into steps
+        for step_num, diff in step_transitions.items():
+            idx = step_num - 1  # step_num is 1-based
+            if 0 <= idx < len(steps_data):
+                steps_data[idx]["transition"] = diff
+
+        metadata = trajectory.get("metadata", {})
+        time_worked: float = 0.0
+        if isinstance(metadata, dict):
+            raw_time = metadata.get("time_worked_s")
+            if isinstance(raw_time, (int, float)):
+                time_worked = float(raw_time)
+        summary = {
+            "steps_taken": len(steps_data),
+            "time_worked_s": round(time_worked, 1),
+            "steps": steps_data,
+        }
+
+        log_dir.mkdir(parents=True, exist_ok=True)
+        steps_path = log_dir / "steps.yaml"
+        steps_path.write_text(yaml.dump(summary, default_flow_style=False, sort_keys=False))
+
+        return {
+            "steps_taken": len(steps_data),
+            "time_worked_s": round(time_worked, 1),
+            "steps_path": str(steps_path),
+        }
+    except Exception:
+        logger.debug("Failed to write steps summary", exc_info=True)
+        return None
+
+
+def _find_latest_trajectory(directory: Path) -> Path | None:
+    """Find the most recently modified trajectory JSON in *directory* (recursive)."""
+    candidates = sorted(directory.rglob("*trajectory*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def _extract_steps(trajectory: dict[str, object]) -> list[dict[str, object]]:
+    """Extract action/detail/url from trajectory steps."""
+    raw_steps = trajectory.get("steps", [])
+    if not isinstance(raw_steps, list):
+        return []
+    result: list[dict[str, object]] = []
+    for raw_step in raw_steps:
+        step = _validate_step(raw_step)
+        if step is None:
+            continue
+        url = step.get("active_url", "")
+        for call in step["program"]["calls"]:
+            name = call["name"]
+            if name in ("waitForPageToSettle", "takeObservation"):
+                continue
+            detail = _summarize_call(name, call["kwargs"])
+            result.append({"action": name, "detail": detail, "url": str(url)})
+    return result
+
+
+def _validate_step(raw: object) -> TrajectoryStep | None:
+    """Validate a raw JSON value as a TrajectoryStep, returning None if malformed."""
+    if not isinstance(raw, dict):
+        return None
+    program = raw.get("program")
+    if not isinstance(program, dict):
+        return None
+    calls = program.get("calls")
+    if not isinstance(calls, list):
+        return None
+    validated_calls: list[TrajectoryCall] = []
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        name = call.get("name")
+        kwargs = call.get("kwargs")
+        if not isinstance(name, str) or not isinstance(kwargs, dict):
+            continue
+        validated_calls.append(TrajectoryCall(name=name, kwargs=kwargs))
+    return TrajectoryStep(
+        program=TrajectoryProgram(calls=validated_calls),
+        active_url=str(raw.get("active_url", "")),
+    )
+
+
+def _summarize_call(name: str, kwargs: dict[str, object]) -> str:
+    """Build a short human-readable detail string for a call."""
+    if name == "think":
+        return str(kwargs.get("text", ""))
+    if name == "return":
+        val = kwargs.get("value", "")
+        return str(val)[:120]
+    # For action calls, stringify kwargs compactly
+    parts = [f"{k}={v}" for k, v in kwargs.items()]
+    return ", ".join(parts)[:120] if parts else ""
+
+
+def _compute_step_transitions(
+    snapshots: list[list[SnapshotElement]],
+) -> dict[int, dict[str, list[dict[str, object]]]]:
+    """Diff consecutive snapshots, returning {step_number: structured_diff}."""
+    from nova_act.cli.browser.services.browser_actions.utils import (
+        generate_structured_transition,
+    )
+
+    transitions: dict[int, dict[str, list[dict[str, object]]]] = {}
+    for i in range(1, len(snapshots)):
+        diff = generate_structured_transition(snapshots[i - 1], snapshots[i])
+        if diff["appeared"] or diff["removed"] or diff["changed"]:
+            transitions[i + 1] = diff  # keyed by 1-based step number
+    return transitions

--- a/src/nova_act/cli/browser/types.py
+++ b/src/nova_act/cli/browser/types.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared types for browser CLI commands."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommandParams:
+    """CLI-facing parameter object grouping the ~16 shared options injected by @browser_command_options.
+
+    This is the raw Click option values — NOT the resolved/SDK-facing BrowserOptions.
+    """
+
+    # Session
+    session_id: str = "default"
+    nova_arg: tuple[str, ...] = ()
+
+    # Browser
+    headless: bool = False
+    headed: bool = False
+    executable_path: str | None = None
+    profile_path: str | None = None
+    launch_arg: tuple[str, ...] = ()
+    ignore_https_errors: bool = True
+
+    # Chrome profile
+    use_default_chrome: bool = False
+    user_data_dir: str | None = None
+
+    # CDP
+    cdp: str | None = None
+
+    # Auth
+    auth_mode: str | None = None
+    profile: str | None = None
+    region: str | None = None
+    workflow_name: str | None = None
+
+    # Output
+    quiet: bool = False
+    verbose: bool = False
+
+    # Screenshot
+    no_screenshot_on_failure: bool = False
+
+    # Observe
+    observe: bool = False
+
+    # Auto-orientation
+    no_snapshot: bool = False
+    no_screenshot: bool = False
+
+
+# Field names that pack_command_params extracts from Click kwargs into CommandParams.
+COMMAND_PARAM_FIELDS: frozenset[str] = frozenset(CommandParams.__dataclass_fields__)

--- a/src/nova_act/cli/browser/utils/__init__.py
+++ b/src/nova_act/cli/browser/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser utilities module."""

--- a/src/nova_act/cli/browser/utils/auth.py
+++ b/src/nova_act/cli/browser/utils/auth.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Authentication utilities for browser CLI commands."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+from nova_act.cli.core.config import get_browser_cli_config_file, read_config
+
+logger = logging.getLogger(__name__)
+
+
+class AuthenticationError(Exception):
+    """Raised when authentication cannot be resolved."""
+
+
+class AuthMode(str, Enum):
+    """Authentication mode for Nova Act CLI."""
+
+    API_KEY = "api-key"
+    AWS = "aws"
+
+
+# Backward-compatible aliases
+AUTH_MODE_API_KEY = AuthMode.API_KEY
+AUTH_MODE_AWS = AuthMode.AWS
+
+DEFAULT_AWS_REGION = "us-east-1"
+DEFAULT_WORKFLOW_NAME = "act-cli"
+NOVA_ACT_API_KEY_ENV = "NOVA_ACT_API_KEY"
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """Resolved authentication configuration.
+
+    Attributes:
+        mode: Authentication mode — "api-key" or "aws".
+        profile: AWS profile name (only relevant for aws mode).
+        region: AWS region (only relevant for aws mode).
+        workflow_name: Workflow definition name (only relevant for aws mode).
+    """
+
+    mode: AuthMode
+    profile: str | None = None
+    region: str | None = None
+    workflow_name: str | None = None
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, object]) -> "AuthConfig | None":
+        """Reconstruct AuthConfig from persisted session metadata.
+
+        Args:
+            metadata: Session metadata dict that may contain an 'auth_config' key.
+
+        Returns:
+            AuthConfig if valid auth config found in metadata, None otherwise.
+        """
+        raw = metadata.get("auth_config")
+        if not raw or not isinstance(raw, dict):
+            return None
+        raw_mode = raw.get("mode")
+        if raw_mode not in (AuthMode.API_KEY.value, AuthMode.AWS.value):
+            return None
+        return cls(
+            mode=AuthMode(raw_mode),
+            profile=raw.get("profile") if isinstance(raw.get("profile"), str) else None,
+            region=raw.get("region") if isinstance(raw.get("region"), str) else None,
+            workflow_name=raw.get("workflow_name") if isinstance(raw.get("workflow_name"), str) else None,
+        )
+
+
+def _read_api_key_from_config() -> str | None:
+    """Read API key from ~/.act_cli/browser/config.yaml if it exists."""
+    try:
+        return read_config().api_key
+    except Exception:
+        logger.debug("Failed to read config file %s", get_browser_cli_config_file(), exc_info=True)
+    return None
+
+
+def has_aws_credentials(profile: str | None) -> bool:
+    """Check if AWS credentials are available via boto3.
+
+    Returns False if boto3 is not installed or no credentials are found.
+    """
+    try:
+        import boto3  # noqa: PLC0415
+    except ImportError:
+        logger.debug("boto3 not installed — AWS auth unavailable")
+        return False
+
+    try:
+        session = boto3.Session(profile_name=profile)
+        return session.get_credentials() is not None
+    except Exception:
+        logger.debug("Failed to check AWS credentials", exc_info=True)
+        return False
+
+
+def _resolve_api_key_auth() -> AuthConfig:
+    """Resolve API key authentication.
+
+    Checks the environment variable first, then falls back to config file.
+
+    Raises:
+        AuthenticationError: If no API key is available.
+    """
+    if os.environ.get(NOVA_ACT_API_KEY_ENV):
+        return AuthConfig(mode=AUTH_MODE_API_KEY)
+    config_key = _read_api_key_from_config()
+    if config_key:
+        os.environ[NOVA_ACT_API_KEY_ENV] = config_key
+        return AuthConfig(mode=AUTH_MODE_API_KEY)
+    raise AuthenticationError(f"Auth mode 'api-key' requires {NOVA_ACT_API_KEY_ENV} environment variable to be set.")
+
+
+def _resolve_aws_auth(
+    profile: str | None,
+    region: str | None,
+    workflow_name: str | None,
+) -> AuthConfig:
+    """Resolve AWS authentication.
+
+    Raises:
+        AuthenticationError: If NOVA_ACT_API_KEY is set (conflicts with AWS mode).
+    """
+    if os.environ.get(NOVA_ACT_API_KEY_ENV):
+        raise AuthenticationError(
+            f"Auth mode 'aws' conflicts with {NOVA_ACT_API_KEY_ENV} environment variable. "
+            f"Either unset {NOVA_ACT_API_KEY_ENV} or use --auth-mode api-key."
+        )
+    return AuthConfig(
+        mode=AUTH_MODE_AWS,
+        profile=profile,
+        region=region or DEFAULT_AWS_REGION,
+        workflow_name=workflow_name or DEFAULT_WORKFLOW_NAME,
+    )
+
+
+def _resolve_auto_detect(
+    profile: str | None,
+    region: str | None,
+    workflow_name: str | None,
+) -> AuthConfig:
+    """Auto-detect authentication from environment.
+
+    Resolution order: env var API key, config file API key, AWS credentials.
+
+    Raises:
+        AuthenticationError: If no auth method is available.
+    """
+    if os.environ.get(NOVA_ACT_API_KEY_ENV):
+        logger.debug("Auto-detected auth mode: api-key (NOVA_ACT_API_KEY is set)")
+        return AuthConfig(mode=AUTH_MODE_API_KEY)
+
+    config_api_key = _read_api_key_from_config()
+    if config_api_key:
+        logger.debug("Auto-detected auth mode: api-key (from config file %s)", get_browser_cli_config_file())
+        os.environ[NOVA_ACT_API_KEY_ENV] = config_api_key
+        return AuthConfig(mode=AUTH_MODE_API_KEY)
+
+    if has_aws_credentials(profile):
+        logger.debug("Auto-detected auth mode: aws (AWS credentials found)")
+        return AuthConfig(
+            mode=AUTH_MODE_AWS,
+            profile=profile,
+            region=region or DEFAULT_AWS_REGION,
+            workflow_name=workflow_name or DEFAULT_WORKFLOW_NAME,
+        )
+
+    raise AuthenticationError(
+        "No authentication configured. Either:\n"
+        f"  - Set {NOVA_ACT_API_KEY_ENV} environment variable for API key auth\n"
+        "  - Run 'act browser setup' to store an API key in local config\n"
+        "  - Configure AWS credentials (env vars, profile, or IAM role) for AWS auth\n"
+        "  - Use --auth-mode to explicitly select an auth method"
+    )
+
+
+def resolve_auth_mode(
+    auth_mode: str | None = None,
+    profile: str | None = None,
+    region: str | None = None,
+    workflow_name: str | None = None,
+) -> AuthConfig:
+    """Resolve authentication mode from explicit flags or auto-detection.
+
+    Resolution order:
+    1. If auth_mode is explicitly provided, use it.
+    2. If NOVA_ACT_API_KEY env var is set, use api-key mode.
+    3. If boto3 can find AWS credentials, use aws mode.
+    4. Raise an error if no auth method is available.
+
+    Args:
+        auth_mode: Explicit auth mode ("api-key" or "aws"), or None for auto-detect.
+        profile: AWS profile name for aws mode.
+        region: AWS region for aws mode (defaults to us-east-1).
+        workflow_name: Workflow definition name for aws mode (defaults to "act-cli").
+
+    Returns:
+        Resolved AuthConfig.
+
+    Raises:
+        AuthenticationError: If auth mode cannot be resolved or configuration is invalid.
+    """
+    import click  # noqa: PLC0415
+
+    try:
+        if auth_mode == AUTH_MODE_API_KEY:
+            return _resolve_api_key_auth()
+        if auth_mode == AUTH_MODE_AWS:
+            return _resolve_aws_auth(profile, region, workflow_name)
+        return _resolve_auto_detect(profile, region, workflow_name)
+    except AuthenticationError as e:
+        raise click.ClickException(str(e)) from e

--- a/src/nova_act/cli/browser/utils/browser_config_cli.py
+++ b/src/nova_act/cli/browser/utils/browser_config_cli.py
@@ -1,0 +1,134 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Browser configuration utilities for browser CLI commands."""
+
+import os
+from dataclasses import dataclass
+
+from nova_act.cli.core.output import exit_with_error
+
+# Constants
+MILLISECONDS_PER_SECOND = 1000
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_SCREENSHOT_QUALITY = 80
+
+
+@dataclass(frozen=True)
+class ScreenshotConfig:
+    """Typed configuration for Playwright page.screenshot() calls.
+
+    Attributes:
+        output_format: Image format ('png' or 'jpeg').
+        full_page: Whether to capture full page or viewport only.
+        quality: JPEG quality (0-100), only set for JPEG format.
+    """
+
+    output_format: str
+    full_page: bool
+    quality: int | None = None
+
+    def to_kwargs(self) -> dict[str, object]:
+        """Convert to kwargs dict for page.screenshot()."""
+        kwargs: dict[str, object] = {"type": self.output_format, "full_page": self.full_page}
+        if self.quality is not None:
+            kwargs["quality"] = self.quality
+        return kwargs
+
+
+def _validate_headless_flags(headless_flag: bool, headed_flag: bool) -> None:
+    """Validate that headless and headed flags are not both set."""
+    if headless_flag and headed_flag:
+        exit_with_error(
+            "Conflicting flags",
+            "Cannot use both --headless and --headed",
+            suggestions=["Use only one: --headless OR --headed"],
+        )
+
+
+def _resolve_from_cli_flags(headless_flag: bool, headed_flag: bool) -> bool | None:
+    """Resolve headless mode from CLI flags, returning None if neither is set."""
+    if headless_flag:
+        return True
+    if headed_flag:
+        return False
+    return None
+
+
+def _resolve_from_environment() -> bool | None:
+    """Resolve headless mode from NOVA_ACT_HEADLESS environment variable.
+
+    Returns:
+        True if env var is truthy, False if falsy, None if not set.
+    """
+    env_headless = os.getenv("NOVA_ACT_HEADLESS", "").strip().lower()
+    if not env_headless:
+        return None
+    return env_headless in ("true", "1", "yes")
+
+
+def determine_headless_mode(headless_flag: bool, headed_flag: bool) -> bool:
+    """Determine effective headless mode with precedence: CLI flags > env > default.
+
+    Precedence:
+    1. CLI flags (--headless or --headed)
+    2. NOVA_ACT_HEADLESS environment variable
+    3. Default: True (headless mode for agent workflows)
+
+    Args:
+        headless_flag: Value of --headless flag
+        headed_flag: Value of --headed flag
+
+    Returns:
+        True for headless mode, False for headed mode
+    """
+    _validate_headless_flags(headless_flag, headed_flag)
+
+    cli_result = _resolve_from_cli_flags(headless_flag, headed_flag)
+    if cli_result is not None:
+        return cli_result
+
+    env_result = _resolve_from_environment()
+    if env_result is not None:
+        return env_result
+
+    return True
+
+
+def convert_timeout_to_ms(timeout: int | None) -> int:
+    """Convert timeout from seconds to milliseconds, using default if None."""
+    if timeout is not None:
+        return timeout * MILLISECONDS_PER_SECOND
+    return DEFAULT_TIMEOUT_SECONDS * MILLISECONDS_PER_SECOND
+
+
+def build_screenshot_kwargs(
+    output_format: str,
+    full_page: bool,
+    quality: int,
+) -> ScreenshotConfig:
+    """Build screenshot config for Playwright page.screenshot() call.
+
+    Args:
+        output_format: Image format ('png' or 'jpeg')
+        full_page: Whether to capture full page or viewport only
+        quality: JPEG quality (0-100), only used for JPEG format
+
+    Returns:
+        ScreenshotConfig dataclass with typed fields.
+    """
+    return ScreenshotConfig(
+        output_format=output_format,
+        full_page=full_page,
+        quality=quality if output_format == "jpeg" else None,
+    )

--- a/src/nova_act/cli/browser/utils/decorators.py
+++ b/src/nova_act/cli/browser/utils/decorators.py
@@ -1,0 +1,229 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Click decorators for browser CLI commands."""
+
+import functools
+from collections.abc import Callable
+from typing import TypeVar
+
+import click
+
+from nova_act.cli.core.json_output import set_json_mode
+
+F = TypeVar("F", bound=Callable[..., object])  # type: ignore[explicit-any]
+
+
+def common_session_options(func: F) -> F:  # type: ignore[explicit-any]
+    """Add common session-related options to a Click command."""
+    func = click.option(
+        "--nova-arg",
+        multiple=True,
+        help="Pass additional NovaAct parameters as KEY=VALUE (repeatable). "
+        "Examples: --nova-arg max_steps=5 --nova-arg screen_width=1920. "
+        "Supports constructor args (headless, screen_width, screen_height) "
+        "and method args (max_steps, model_temperature, observation_delay_ms).",
+    )(func)
+    func = click.option("--session-id", default="default", help="Session ID (default: 'default')")(func)
+    return func
+
+
+def auth_options(func: F) -> F:  # type: ignore[explicit-any]
+    """Add authentication options to a Click command.
+
+    Adds --auth-mode, --profile, --region, and --workflow-name options.
+    Apply AFTER common_session_options in the decorator stack.
+    """
+    func = click.option(
+        "--workflow-name",
+        default=None,
+        help="Workflow definition name for AWS auth (default: 'act-cli')",
+    )(func)
+    func = click.option(
+        "--region",
+        default=None,
+        help="AWS region for AWS auth (default: us-east-1)",
+    )(func)
+    func = click.option(
+        "--aws-profile",
+        "profile",
+        default=None,
+        help="AWS profile name for AWS auth",
+    )(func)
+    func = click.option(
+        "--auth-mode",
+        type=click.Choice(["api-key", "aws"]),
+        default=None,
+        help="Authentication mode (auto-detected if not specified)",
+    )(func)
+    return func
+
+
+def common_browser_options(func: F) -> F:  # type: ignore[explicit-any]
+    """Add common browser configuration options to a Click command."""
+    func = click.option(
+        "--user-data-dir",
+        default=None,
+        help="Working directory for Chrome profile (auto-created if not specified with --use-default-chrome)",
+    )(func)
+    func = click.option(
+        "--use-default-chrome",
+        is_flag=True,
+        default=False,
+        help="Use default Chrome browser with extensions (quits running Chrome, rsyncs profile)",
+    )(func)
+    func = click.option(
+        "--launch-arg",
+        multiple=True,
+        help="Additional Chrome launch argument (repeatable, e.g. --launch-arg=--ignore-certificate-errors)",
+    )(func)
+    func = click.option(
+        "--ignore-https-errors/--no-ignore-https-errors",
+        default=True,
+        help="Ignore HTTPS certificate errors (enabled by default)",
+    )(func)
+    func = click.option(
+        "--browser-profile-path",
+        "profile_path",
+        help="Path to browser profile directory for persistent sessions",
+    )(func)
+    func = click.option(
+        "--executable-path",
+        help="Path to custom Chromium-based browser executable",
+    )(func)
+    func = click.option(
+        "--headed",
+        is_flag=True,
+        default=False,
+        help="Launch browser in headed mode (visible UI)",
+    )(func)
+    func = click.option(
+        "--headless",
+        is_flag=True,
+        default=False,
+        help="Launch browser in headless mode (no visible UI)",
+    )(func)
+    func = click.option(
+        "--cdp",
+        default=None,
+        help="Connect to an existing browser via CDP endpoint URL (e.g. ws://localhost:9222/devtools/browser/...)",
+    )(func)
+    return func
+
+
+def json_option(func: F) -> F:  # type: ignore[explicit-any]
+    """Add --json flag that enables structured JSON output mode."""
+
+    def _set_json_mode(ctx: click.Context, param: click.Parameter, value: bool) -> None:  # noqa: ARG001
+        if value:
+            set_json_mode(True)
+
+    return click.option(
+        "--json",
+        "json_flag",
+        is_flag=True,
+        default=False,
+        is_eager=True,
+        expose_value=False,
+        callback=_set_json_mode,
+        help="Output results as structured JSON",
+    )(func)
+
+
+def quiet_option(func: F) -> F:  # type: ignore[explicit-any]
+    """Add --quiet/-q flag to suppress SDK stdout output during execution."""
+    return click.option(
+        "--quiet",
+        "-q",
+        is_flag=True,
+        default=False,
+        help="Suppress SDK output for token efficiency (use with --json for minimal output)",
+    )(func)
+
+
+def verbose_option(func: F) -> F:  # type: ignore[explicit-any]
+    """Add --verbose/-v flag for human-friendly decorated output with full SDK trace."""
+    return click.option(
+        "--verbose",
+        "-v",
+        is_flag=True,
+        default=False,
+        help="Show decorated output with full SDK trace for interactive debugging",
+    )(func)
+
+
+def browser_command_options(func: F) -> F:  # type: ignore[explicit-any]
+    """Composite decorator for all browser commands (browsing/ + extraction/).
+
+    Combines: common_browser_options, common_session_options, auth_options,
+    json_option, quiet_option, verbose_option, no_screenshot_on_failure — in the correct Click application order.
+    """
+    func = click.option(
+        "--observe",
+        is_flag=True,
+        default=False,
+        help="After command completes, describe the current page layout",
+    )(func)
+    func = click.option(
+        "--no-screenshot",
+        is_flag=True,
+        default=False,
+        help="Skip automatic screenshot capture after command completes",
+    )(func)
+    func = click.option(
+        "--no-snapshot",
+        is_flag=True,
+        default=False,
+        help="Skip automatic accessibility snapshot after command completes",
+    )(func)
+    func = click.option(
+        "--no-screenshot-on-failure",
+        is_flag=True,
+        default=False,
+        help="Disable automatic screenshot capture on act() failure",
+    )(func)
+    func = verbose_option(func)
+    func = quiet_option(func)
+    func = json_option(func)
+    func = auth_options(func)
+    func = common_session_options(func)
+    func = common_browser_options(func)
+    return func
+
+
+def setup_command_options(func: F) -> F:  # type: ignore[explicit-any]
+    """Composite decorator for setup/diagnostic commands (doctor, setup).
+
+    Combines: json_option, verbose_option.
+    """
+    func = verbose_option(func)
+    func = json_option(func)
+    return func
+
+
+def pack_command_params(func: F) -> F:  # type: ignore[explicit-any]
+    """Decorator that packs shared CLI kwargs into a CommandParams object.
+
+    Place AFTER @handle_common_errors (innermost) so it runs before error handling.
+    Extracts the ~16 shared kwargs injected by @browser_command_options, creates
+    a CommandParams instance, and passes it as ``params`` to the wrapped function.
+    """
+    from nova_act.cli.browser.types import COMMAND_PARAM_FIELDS, CommandParams
+
+    @functools.wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        param_kwargs = {k: kwargs.pop(k) for k in list(kwargs) if k in COMMAND_PARAM_FIELDS}
+        kwargs["params"] = CommandParams(**param_kwargs)  # type: ignore[arg-type]
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]

--- a/src/nova_act/cli/browser/utils/disk_usage.py
+++ b/src/nova_act/cli/browser/utils/disk_usage.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Disk usage monitoring for browser CLI data directory."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DISK_WARNING_THRESHOLD_BYTES = 5 * 1024 * 1024 * 1024  # 5GB
+
+
+def check_disk_usage(base_dir: Path) -> str | None:
+    """Return warning message if dir exceeds threshold, else None."""
+    try:
+        total = sum(f.stat().st_size for f in base_dir.rglob("*") if f.is_file())
+        if total >= DISK_WARNING_THRESHOLD_BYTES:
+            gb = total / (1024**3)
+            return (
+                f"Browser CLI data directory is {gb:.1f}GB. Run 'act browser session prune --ignore-ttl' to free space."
+            )
+    except Exception:
+        logger.debug("Failed to check disk usage for %s", base_dir, exc_info=True)
+    return None

--- a/src/nova_act/cli/browser/utils/error_handlers.py
+++ b/src/nova_act/cli/browser/utils/error_handlers.py
@@ -1,0 +1,311 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Error handling decorators for browser CLI commands."""
+
+import functools
+import logging
+import sys
+from collections.abc import Callable
+from typing import NamedTuple, TypeVar
+
+import click
+
+from nova_act.cli.browser.utils.log_capture import _build_log_path
+from nova_act.cli.core.exceptions import (
+    BrowserProcessDead,
+    SessionLimitReached,
+    SessionLockTimeout,
+)
+from nova_act.cli.core.json_output import ErrorCode, is_json_mode, json_error
+from nova_act.cli.core.output import (
+    exit_with_error,
+    get_current_log_path,
+    is_verbose_mode,
+    set_current_log_dir,
+    set_current_log_path,
+    set_verbose_mode,
+)
+from nova_act.types.act_errors import (
+    ActExceededMaxStepsError,
+    ActGuardrailsError,
+    ActRateLimitExceededError,
+    ActTimeoutError,
+)
+from nova_act.types.errors import AuthError, IAMAuthError
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., object])  # type: ignore[explicit-any]
+
+
+def _get_failure_details(e: Exception) -> dict[str, str] | None:
+    """Extract failure screenshot details from an exception, if attached."""
+    screenshot = getattr(e, "_failure_screenshot", None)
+    return {"failure_screenshot": screenshot} if screenshot else None
+
+
+def _is_chrome_not_found(e: Exception) -> bool:
+    """Check if an exception indicates Chrome was not found."""
+    msg = str(e).lower()
+    return "chrome" in msg and ("not found" in msg or "no such file" in msg or "executable" in msg)
+
+
+def _handle_chrome_not_found(e: Exception, details: dict[str, str] | None) -> bool:
+    """Handle Chrome-not-found errors. Returns True if the error was handled."""
+    if not _is_chrome_not_found(e):
+        return False
+    exit_with_error(
+        "Chrome not found",
+        str(e),
+        suggestions=[
+            "Run 'act browser doctor' to diagnose browser issues",
+            "Specify a custom path: --executable-path /path/to/chrome",
+        ],
+        error_code=ErrorCode.CHROME_NOT_FOUND,
+        details=details,
+    )
+    return True  # exit_with_error calls sys.exit, but needed for testability
+
+
+def _is_browser_validation_error(e: Exception) -> bool:
+    """Check if an exception is a browser validation error with a specific message."""
+    msg = str(e).lower()
+    return any(
+        indicator in msg for indicator in ["not chromium", "not a directory", "invalid profile", "missing preferences"]
+    )
+
+
+def _handle_browser_validation_error(e: Exception, details: dict[str, str] | None) -> bool:
+    """Handle browser validation errors (non-chromium, bad profile, etc.). Returns True if handled."""
+    if not isinstance(e, RuntimeError) or not _is_browser_validation_error(e):
+        return False
+    exit_with_error(
+        "Browser validation failed",
+        str(e),
+        suggestions=[
+            "Verify the browser is Chromium-based (Chrome, Chromium, or Edge)",
+            "Ensure the profile path is a valid directory with a Preferences file",
+        ],
+        error_code=ErrorCode.VALIDATION_ERROR,
+        details=details,
+    )
+    return True  # exit_with_error calls sys.exit, but needed for testability
+
+
+def _handle_runtime_error(e: Exception, details: dict[str, str] | None) -> bool:
+    """Handle RuntimeError with generic browser error messaging. Returns True if handled."""
+    if not isinstance(e, RuntimeError) or isinstance(e, click.exceptions.Exit):
+        return False
+    exit_with_error(
+        str(e),
+        "A runtime error occurred during command execution.",
+        suggestions=["Check browser installation", "Verify system resources are available"],
+        error_code=ErrorCode.BROWSER_ERROR,
+        details=details,
+    )
+    return True  # exit_with_error calls sys.exit, but needed for testability
+
+
+class _SdkErrorMapping(NamedTuple):
+    """Maps an SDK error type to its user-facing error presentation."""
+
+    error_type: type[Exception]
+    title: str
+    default_message: str
+    suggestions: list[str]
+    error_code: ErrorCode
+    retryable: bool
+
+
+_SDK_ERROR_MAP: list[_SdkErrorMapping] = [
+    _SdkErrorMapping(
+        IAMAuthError,
+        "AWS authentication failed",
+        "",
+        [
+            "Verify credentials: aws sts get-caller-identity --profile <profile>",
+            "Refresh credentials: ada credentials update --profile <profile> ...",
+            "Check region: --region us-east-1",
+        ],
+        ErrorCode.AUTH_ERROR,
+        False,
+    ),
+    _SdkErrorMapping(
+        AuthError,
+        "Authentication failed",
+        "",
+        [
+            "Verify your API key: --nova-arg nova_act_api_key=<key>",
+            "Or switch to AWS auth: --auth-mode aws --aws-profile <profile>",
+        ],
+        ErrorCode.AUTH_ERROR,
+        False,
+    ),
+    _SdkErrorMapping(
+        ActTimeoutError,
+        "Action timed out",
+        "The act() call exceeded its timeout.",
+        [
+            "Increase --timeout or simplify the prompt",
+            "Break complex actions into smaller steps",
+        ],
+        ErrorCode.ACT_TIMEOUT_ERROR,
+        True,
+    ),
+    _SdkErrorMapping(
+        ActExceededMaxStepsError,
+        "Max steps exceeded",
+        "The action exceeded the maximum number of steps.",
+        [
+            "Increase max_steps: --nova-arg max_steps=<N>",
+            "Simplify the prompt to require fewer steps",
+        ],
+        ErrorCode.ACT_MAX_STEPS_ERROR,
+        True,
+    ),
+    _SdkErrorMapping(
+        ActGuardrailsError,
+        "Guardrails blocked action",
+        "The action was blocked by safety guardrails.",
+        [
+            "Rephrase the prompt to avoid restricted content",
+            "Review guardrail policies for your account",
+        ],
+        ErrorCode.ACT_GUARDRAILS_ERROR,
+        False,
+    ),
+    _SdkErrorMapping(
+        ActRateLimitExceededError,
+        "Rate limit exceeded",
+        "API rate limit exceeded.",
+        [
+            "Wait and retry after a short delay",
+            "Reduce request frequency",
+        ],
+        ErrorCode.ACT_RATE_LIMIT_ERROR,
+        True,
+    ),
+]
+
+
+def _handle_sdk_error(e: Exception, details: dict[str, str] | None) -> bool:
+    """Handle SDK-specific errors. Returns True if the error was handled."""
+    for mapping in _SDK_ERROR_MAP:
+        if isinstance(e, mapping.error_type):
+            exit_with_error(
+                mapping.title,
+                str(e) or mapping.default_message,
+                suggestions=mapping.suggestions,
+                error_code=mapping.error_code,
+                retryable=mapping.retryable,
+                details=details,
+            )
+            return True  # exit_with_error calls sys.exit, but needed for testability
+    return False
+
+
+def _handle_keyboard_interrupt(session_id: str) -> None:
+    """Handle KeyboardInterrupt with JSON or text output, then exit."""
+    log_path = get_current_log_path()
+    if is_json_mode():
+        json_error(
+            ErrorCode.INTERRUPTED, f"Operation interrupted. Session '{session_id}' preserved.", log_path=log_path
+        )
+        sys.exit(130)
+    click.echo(
+        f"\nInterrupted. Session '{session_id}' preserved "
+        f"— use 'act browser session close {session_id}' to clean up."
+    )
+    if log_path:
+        from pathlib import Path
+
+        click.echo(f"log_dir: {str(Path(log_path).parent)}")
+    sys.exit(130)
+
+
+def handle_common_errors(func: F) -> F:  # type: ignore[explicit-any]
+    """Decorator to handle common browser command errors."""
+
+    @functools.wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        if kwargs.get("verbose"):
+            set_verbose_mode(True)
+        # Set up log path early so exit_with_error always has a valid log path,
+        # even for errors that fire before command_session() enters capture_command_log().
+        # If command_session() runs later, it overwrites these with the real values.
+        if not get_current_log_path():
+            session_id = str(kwargs.get("session_id", "default"))
+            command_name = func.__name__.replace("_", "-")
+            log_path, cmd_dir = _build_log_path(session_id, command_name)
+            set_current_log_path(str(log_path))
+            set_current_log_dir(str(cmd_dir))
+        try:
+            return func(*args, **kwargs)
+        except click.exceptions.Exit:
+            raise
+        except KeyboardInterrupt:
+            _handle_keyboard_interrupt(str(kwargs.get("session_id", "default")))
+        except SessionLockTimeout as e:
+            exit_with_error(
+                "Session is busy",
+                str(e),
+                suggestions=["Wait for the current operation to complete", "Use a different session with --session-id"],
+                error_code=ErrorCode.SESSION_BUSY,
+                retryable=True,
+            )
+        except SessionLimitReached as e:
+            exit_with_error(
+                "Session limit reached",
+                str(e),
+                suggestions=[
+                    "Close unused sessions: act browser session close-all",
+                    "Prune stale sessions: act browser session prune",
+                    "Increase limit: --max-sessions <N>",
+                ],
+                error_code=ErrorCode.SESSION_LIMIT_REACHED,
+            )
+        except BrowserProcessDead as e:
+            exit_with_error(
+                "Browser process died",
+                str(e),
+                suggestions=[
+                    "Close the session: act browser session close --force",
+                    "Create a new session: act browser session create <url>",
+                ],
+                error_code=ErrorCode.BROWSER_ERROR,
+            )
+        except Exception as e:
+            details = _get_failure_details(e)
+            if _handle_sdk_error(e, details):
+                return None
+            if _handle_chrome_not_found(e, details):
+                return None
+            if _handle_browser_validation_error(e, details):
+                return None
+            if _handle_runtime_error(e, details):
+                return None
+            if is_verbose_mode():
+                logger.error("Unexpected error in %s", func.__name__, exc_info=True)
+            else:
+                logger.warning("Unexpected error in %s: %s", func.__name__, e)
+            exit_with_error(
+                f"{func.__name__.replace('_', ' ').title()} failed",
+                str(e),
+                suggestions=["Check that the browser session is active", "Try again or use a different session"],
+                error_code=ErrorCode.UNEXPECTED_ERROR,
+                details=details,
+            )
+        return None
+
+    return wrapper  # type: ignore[return-value]

--- a/src/nova_act/cli/browser/utils/file_output.py
+++ b/src/nova_act/cli/browser/utils/file_output.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared file output utilities for CLI commands."""
+
+import errno
+import json
+import pathlib
+from typing import NamedTuple
+
+from nova_act.cli.browser.utils.log_capture import get_current_command_dir
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import exit_with_error
+
+
+class OutputPathConfig(NamedTuple):
+    """Configuration for auto-generated output file paths."""
+
+    filename: str
+    ext: str
+
+
+def resolve_output_path(output: str | None, filename: str, ext: str) -> str:
+    """Validate user-provided output path or auto-generate one inside the command subdir."""
+    if output:
+        validate_output_dir(output)
+        return output
+    return generate_output_path(filename, ext)
+
+
+def generate_output_path(filename: str, ext: str) -> str:
+    """Generate output path inside the current per-command subdirectory."""
+    cmd_dir = get_current_command_dir()
+    if cmd_dir is None:
+        raise RuntimeError("generate_output_path called outside capture_command_log context")
+    cmd_dir.mkdir(parents=True, exist_ok=True)
+    return str(cmd_dir / f"{filename}.{ext}")
+
+
+def write_output_file(path: str, content: str | bytes) -> int:
+    """Write content to file, returning bytes written. Exits on error."""
+    try:
+        p = pathlib.Path(path)
+        if isinstance(content, bytes):
+            p.write_bytes(content)
+            return len(content)
+        p.write_text(content, encoding="utf-8")
+        return len(content.encode("utf-8"))
+    except OSError as e:
+        msg = "Not enough disk space" if e.errno == errno.ENOSPC else str(e)
+        exit_with_error(
+            "File write error",
+            msg,
+            suggestions=["Check file permissions", "Verify output path exists"],
+            error_code=ErrorCode.FILE_ERROR,
+        )
+        return 0  # unreachable
+
+
+def validate_output_dir(path: str) -> None:
+    """Exit with error if the parent directory of path doesn't exist."""
+    parent = pathlib.Path(path).parent
+    if not parent.exists():
+        exit_with_error(
+            "Invalid output path",
+            f"Directory does not exist: {parent}",
+            suggestions=["Create the directory first", "Use a different output path"],
+            error_code=ErrorCode.FILE_ERROR,
+        )
+
+
+def format_result(result: object, output_format: str) -> str:
+    """Format a result based on output format."""
+    if output_format == "json":
+        if isinstance(result, dict):
+            return json.dumps(result, indent=2)
+        else:
+            # Wrap string result in JSON object
+            return json.dumps({"result": result}, indent=2)
+    else:
+        if isinstance(result, (dict, list)):
+            return json.dumps(result, indent=2, default=str)
+        return str(result)

--- a/src/nova_act/cli/browser/utils/log_capture.py
+++ b/src/nova_act/cli/browser/utils/log_capture.py
@@ -1,0 +1,381 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Automatic log capture and stdout management for browser CLI commands.
+
+Provides two complementary stdout control mechanisms:
+- suppress_sdk_output(): Silences SDK stdout/trace during session setup (no logging).
+- capture_command_log(): Captures SDK output to per-command log files during execution.
+
+Both mechanisms suppress the nova_act.trace logger and redirect stdout. They are used
+sequentially (suppress during setup, capture during command execution) and should not
+be nested.
+"""
+
+import io
+import logging as _logging
+import os
+import re
+import shutil
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from nova_act.cli.core.config import get_log_base_dir
+from nova_act.cli.core.output import (
+    set_current_log_dir,
+    set_current_log_path,
+    set_original_stdout,
+    set_quiet_mode,
+)
+
+LOG_BASE_DIR = get_log_base_dir()
+SYSTEM_LOG_DIR = LOG_BASE_DIR / "_system"
+
+_TRACE_LOGGER_NAME = "nova_act.trace"
+_SDK_ROOT_LOGGER_NAME = "nova_act"
+
+# SDK loggers that emit noise during session setup but may not yet exist in the
+# logger registry (their modules are lazily imported by the SDK).  Explicitly
+# creating them via getLogger() before suppression ensures they are captured.
+_KNOWN_SDK_LOGGER_NAMES = (
+    "nova_act",
+    "nova_act.trace",
+    "nova_act.nova_act",
+    "nova_act.types.workflow",
+)
+
+_CMD_DIR_PATTERN = re.compile(r"^\d{8}_\d{6}_\w+$")
+_CLI_LOG_SUFFIXES = {".log", ".yaml", ".png", ".txt"}
+
+_current_command_dir: Path | None = None
+
+
+def get_current_command_dir() -> Path | None:
+    """Get the per-command subdirectory for the currently executing command."""
+    return _current_command_dir
+
+
+def set_current_command_dir(path: Path | None) -> None:
+    """Set the per-command subdirectory for the currently executing command."""
+    global _current_command_dir
+    _current_command_dir = path
+
+
+def _get_sdk_loggers() -> list[_logging.Logger]:
+    """Get all loggers in the nova_act namespace (including children with propagate=False).
+
+    Also pre-creates known SDK loggers that may not yet exist in the registry
+    because their modules are lazily imported.  This ensures suppress_sdk_output()
+    and capture_command_log() can silence them before the SDK code runs.
+    """
+    # Pre-create known noisy loggers so they appear in the registry
+    for name in _KNOWN_SDK_LOGGER_NAMES:
+        _logging.getLogger(name)
+
+    prefix = _SDK_ROOT_LOGGER_NAME + "."
+    return [
+        _logging.getLogger(name)
+        for name in _logging.Logger.manager.loggerDict
+        if name == _SDK_ROOT_LOGGER_NAME or name.startswith(prefix)
+    ]
+
+
+@contextmanager
+def suppress_sdk_output() -> Iterator[None]:
+    """Suppress SDK stdout/stderr output (trace logs, thinker dots, workflow messages) during SDK calls.
+
+    Used during session setup where no log file capture is needed.
+    For command execution, use capture_command_log() instead.
+
+    SDK loggers use propagate=False with their own StreamHandlers, so we must
+    set levels on ALL child loggers, not just the root nova_act logger.
+    """
+    sdk_loggers = _get_sdk_loggers()
+    old_levels = [(logger, logger.level) for logger in sdk_loggers]
+    for logger in sdk_loggers:
+        logger.setLevel(_logging.CRITICAL)
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    devnull = open(os.devnull, "w")  # noqa: SIM115
+    try:
+        sys.stdout = devnull
+        sys.stderr = devnull
+        yield
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        devnull.close()
+        for logger, level in old_levels:
+            logger.setLevel(level)
+
+
+def get_log_dir(session_id: str | None) -> Path:
+    """Get log directory for a session (or _system for session-less commands)."""
+    if session_id:
+        return LOG_BASE_DIR / session_id
+    return SYSTEM_LOG_DIR
+
+
+def _build_command_dir(session_id: str | None, command_name: str) -> Path:
+    """Build per-command subdirectory: <session_log_dir>/<timestamp>_<command>/"""
+    log_dir = get_log_dir(session_id)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    cmd_dir = log_dir / f"{timestamp}_{command_name}"
+    cmd_dir.mkdir(parents=True, exist_ok=True)
+    return cmd_dir
+
+
+def _build_log_path(session_id: str | None, command_name: str) -> tuple[Path, Path]:
+    """Build log file path: <session_log_dir>/<timestamp>_<command>/log.txt
+
+    Returns:
+        Tuple of (log_file_path, command_dir_path).
+    """
+    cmd_dir = _build_command_dir(session_id, command_name)
+    return cmd_dir / "log.txt", cmd_dir
+
+
+def _write_metadata_header(
+    f: io.TextIOWrapper, command_name: str, session_id: str | None, args: dict[str, object] | None
+) -> None:
+    """Write YAML metadata header to log file."""
+    metadata: dict[str, object] = {
+        "timestamp": datetime.now().isoformat(),
+        "command": command_name,
+    }
+    if session_id:
+        metadata["session_id"] = session_id
+    if args:
+        metadata["args"] = args
+    yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
+    f.write("---\n")
+    f.flush()
+
+
+class _TeeWriter:
+    """Writes to a log file and optionally to an original stream."""
+
+    def __init__(self, log_file: io.TextIOWrapper, original: io.TextIOBase | io.TextIOWrapper | None) -> None:
+        self.log_file = log_file
+        self.original = original
+
+    def write(self, data: str) -> int:
+        self.log_file.write(data)
+        self.log_file.flush()
+        if self.original is not None:
+            self.original.write(data)
+            self.original.flush()
+        return len(data)
+
+    def flush(self) -> None:
+        self.log_file.flush()
+        if self.original is not None:
+            self.original.flush()
+
+    # Support fileno() for compatibility — delegate to original or raise
+    def fileno(self) -> int:
+        if self.original is not None and hasattr(self.original, "fileno"):
+            return self.original.fileno()
+        raise io.UnsupportedOperation("fileno")
+
+    def isatty(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+
+def _patch_stream_handlers(
+    logger: _logging.Logger, old_stream: io.TextIOBase | io.TextIOWrapper, new_stream: object
+) -> list[tuple[_logging.StreamHandler, io.TextIOBase | io.TextIOWrapper]]:  # type: ignore[type-arg]
+    """Update StreamHandlers pointing at old_stream to use new_stream. Returns originals for restore."""
+    patched: list[tuple[_logging.StreamHandler, io.TextIOBase | io.TextIOWrapper]] = []  # type: ignore[type-arg]
+    for handler in logger.handlers:
+        if isinstance(handler, _logging.StreamHandler) and handler.stream is old_stream:
+            patched.append((handler, handler.stream))
+            handler.stream = new_stream
+    return patched
+
+
+@contextmanager
+def capture_command_log(
+    command_name: str,
+    session_id: str | None = None,
+    args: dict[str, object] | None = None,
+    quiet: bool = False,
+    verbose: bool = False,
+) -> Iterator[Path]:
+    """Context manager that captures SDK output to a log file.
+
+    Replaces sys.stdout/sys.stderr with _TeeWriter instances to intercept SDK output
+    and write it to a per-command log file. CLI output functions bypass the tee via
+    set_original_stdout() to write directly to the real terminal.
+
+    Known limitation (RISK-T1, accepted for v1):
+        This replaces global sys.stdout/sys.stderr, which is inherently fragile in
+        multi-threaded or multi-process contexts. For v1 this is acceptable because:
+        - The CLI is single-threaded and single-process
+        - The _TeeWriter pattern works correctly in production (every command uses it)
+        - Tests use a noop context manager patch to avoid interference with Click's runner
+        Future fix: replace stdout/stderr replacement with a logging.FileHandler-based
+        approach that captures SDK trace output without touching global streams.
+
+    Note on FileHandler alternative (evaluated and rejected for v1):
+        logging.FileHandler on nova_act.trace was considered but rejected because
+        the SDK prints directly to stdout (not via the logging module), so a
+        FileHandler would miss all SDK output. The TeeWriter approach is required
+        until the SDK migrates to proper logging.
+
+    Args:
+        command_name: Name of the CLI command (e.g. "execute", "navigate")
+        session_id: Session ID (None for session-less commands like doctor)
+        args: Command arguments to record in metadata header
+        quiet: If True, suppress terminal output (only log file gets SDK trace)
+        verbose: If True, show full SDK trace on terminal (decorated mode)
+
+    Yields:
+        Path to the log file
+    """
+    log_path, cmd_dir = _build_log_path(session_id, command_name)
+    log_file = open(log_path, "w")  # noqa: SIM115
+
+    _write_metadata_header(log_file, command_name, session_id, args)
+
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+
+    # Save original stdout so CLI output functions can bypass the tee writer
+    set_original_stdout(old_stdout)
+
+    # Set quiet mode so output functions know to emit only log path
+    set_quiet_mode(quiet)
+
+    # Determine terminal visibility for stdout
+    # Default: suppress SDK trace on terminal (log file only)
+    # Verbose: show full SDK trace on terminal
+    # Quiet: suppress terminal output (same as default, explicit intent)
+    terminal_out = old_stdout if verbose else None
+    terminal_err = old_stderr if verbose else None
+
+    tee_out = _TeeWriter(log_file, terminal_out)  # type: ignore[arg-type]
+    tee_err = _TeeWriter(log_file, terminal_err)  # type: ignore[arg-type]
+
+    # Capture all SDK loggers and save levels before modifying.
+    # SDK loggers use propagate=False with their own StreamHandlers, so we must
+    # set levels on ALL child loggers, not just the root nova_act logger.
+    sdk_loggers = _get_sdk_loggers()
+    old_levels = [(logger, logger.level) for logger in sdk_loggers]
+    if not verbose:
+        for logger in sdk_loggers:
+            logger.setLevel(_logging.CRITICAL)
+
+    sys.stdout = tee_out
+    sys.stderr = tee_err
+
+    # Fix stale StreamHandler references: handlers captured sys.stderr at creation
+    # time, so replacing stderr doesn't redirect their output to the TeeWriter.
+    patched_handlers: list[  # type: ignore[type-arg]
+        tuple[_logging.StreamHandler, io.TextIOBase | io.TextIOWrapper]
+    ] = []
+    for logger in sdk_loggers:
+        patched_handlers += _patch_stream_handlers(logger, old_stderr, tee_err)  # type: ignore[arg-type]
+
+    set_current_log_path(str(log_path))
+    set_current_log_dir(str(cmd_dir))
+    set_current_command_dir(cmd_dir)
+    try:
+        yield log_path
+    finally:
+        # NOTE: Do NOT clear log_path here. Commands call echo_success() AFTER
+        # exiting command_session(), so the log path must remain available for
+        # json_success() / exit_with_error() to include "log" in the output.
+        # Each CLI invocation is a separate process, so no state leakage.
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        set_original_stdout(None)
+        set_quiet_mode(False)
+        for logger, level in old_levels:
+            logger.setLevel(level)
+        for handler, original_stream in patched_handlers:
+            handler.stream = original_stream
+        log_file.close()
+
+
+def build_failure_screenshot_path(session_id: str | None, command_name: str) -> Path:
+    """Build path for failure screenshot inside the current command subdirectory."""
+    cmd_dir = get_current_command_dir()
+    if cmd_dir is not None:
+        return cmd_dir / "failure.png"
+    # Fallback if called outside capture_command_log context
+    fallback_dir = _build_command_dir(session_id, command_name)
+    return fallback_dir / "failure.png"
+
+
+def capture_failure_screenshot(
+    nova_act: object,
+    session_id: str | None,
+    command_name: str,
+) -> str | None:
+    """Capture a screenshot on failure, returning the saved path or None.
+
+    Args:
+        nova_act: NovaAct instance (typed as object to avoid import cycle).
+        session_id: Session ID for log directory placement.
+        command_name: Command name for the screenshot filename.
+    """
+    try:
+        screenshot_path = build_failure_screenshot_path(session_id, command_name)
+        screenshot_bytes = nova_act.page.screenshot()  # type: ignore[attr-defined]
+        screenshot_path.write_bytes(screenshot_bytes)
+        return str(screenshot_path)
+    except Exception:
+        return None
+
+
+def cleanup_session_logs(session_id: str) -> None:
+    """Remove CLI-generated log files for a session, preserving SDK artifact subdirectories.
+
+    The SDK writes trajectory JSON and HTML reports into nested <sdk_session_id>/
+    subdirectories under the session log dir. CLI commands write into per-command
+    subdirectories (e.g. 20260330_155318_execute/). This function deletes CLI command
+    subdirectories (matching <timestamp>_<command>/ pattern) while preserving SDK
+    artifact subdirectories.
+    """
+    log_dir = get_log_dir(session_id)
+    if not log_dir.exists():
+        return
+
+    # Safeguard: only delete within the CLI log base directory
+    try:
+        log_dir.resolve().relative_to(LOG_BASE_DIR.resolve())
+    except ValueError:
+        return
+
+    for item in list(log_dir.iterdir()):
+        if item.is_dir() and _CMD_DIR_PATTERN.match(item.name):
+            # CLI command subdirectory — remove entirely
+            shutil.rmtree(item, ignore_errors=True)
+        elif item.is_file() and item.suffix in _CLI_LOG_SUFFIXES:
+            # Legacy flat files from before per-command subdirs
+            item.unlink(missing_ok=True)
+
+    # Remove the session dir only if it's now empty (all SDK subdirs were already gone)
+    try:
+        log_dir.rmdir()  # only succeeds if empty
+    except OSError:
+        pass  # subdirectories remain — expected

--- a/src/nova_act/cli/browser/utils/nova_args.py
+++ b/src/nova_act/cli/browser/utils/nova_args.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NovaAct argument parsing and handling utilities."""
+
+from nova_act.cli.core.nova_args import parse_nova_arg, validate_and_coerce_nova_args
+from nova_act.cli.core.output import exit_with_error
+
+# NovaAct method-only arguments (not valid for constructor)
+METHOD_ONLY_ARGS = frozenset({"max_steps", "model_temperature", "model_top_k", "model_seed", "observation_delay_ms"})
+
+
+def parse_nova_args(nova_arg: tuple[str, ...]) -> dict[str, object]:
+    """Parse and validate nova_arg tuples into dict."""
+    if not nova_arg:
+        return {}
+    try:
+        raw_args: dict[str, object] = {}
+        for arg in nova_arg:
+            key, value = parse_nova_arg(arg)
+            raw_args[key] = value
+        return validate_and_coerce_nova_args(raw_args)
+    except ValueError as e:
+        exit_with_error(
+            "Invalid NovaAct argument",
+            str(e),
+            suggestions=[
+                "Use format: --nova-arg key=value",
+                "Example: --nova-arg headless=true",
+                "Example: --nova-arg screen_width=1920",
+            ],
+        )
+        return {}  # Unreachable, but satisfies type checker
+
+
+def filter_constructor_args(nova_args: dict[str, object]) -> dict[str, object]:
+    """Filter nova_args to only constructor-valid arguments.
+
+    Removes method-only parameters (defined in METHOD_ONLY_ARGS) that are
+    only valid for act()/act_get() calls, not the NovaAct constructor.
+
+    Args:
+        nova_args: Combined dictionary of all --nova-arg parameters
+
+    Returns:
+        Dictionary of constructor-valid arguments
+    """
+    return {k: v for k, v in nova_args.items() if k not in METHOD_ONLY_ARGS}
+
+
+def filter_method_args(nova_args: dict[str, object]) -> dict[str, object]:
+    """Filter nova_args to only method-level arguments.
+
+    Extracts parameters that are only valid for act()/act_get() method calls
+    (defined in METHOD_ONLY_ARGS), not the NovaAct constructor.
+
+    Method-only parameters:
+    - max_steps: Maximum number of browser automation steps
+    - model_temperature: Model temperature for generation
+    - model_top_k: Model top-k sampling parameter
+    - model_seed: Model random seed
+    - observation_delay_ms: Delay between observations
+
+    Args:
+        nova_args: Combined dictionary of all --nova-arg parameters
+
+    Returns:
+        Dictionary of method-only arguments
+    """
+    return {k: v for k, v in nova_args.items() if k in METHOD_ONLY_ARGS}

--- a/src/nova_act/cli/browser/utils/orientation.py
+++ b/src/nova_act/cli/browser/utils/orientation.py
@@ -1,0 +1,141 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Post-command orientation utilities: observe, snapshot, screenshot, and steps summary."""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+from typing import TYPE_CHECKING
+
+import click
+import yaml
+
+from nova_act import NovaAct
+from nova_act.cli.browser.services.browser_actions.utils import run_observe
+from nova_act.cli.browser.services.session.models import SessionInfo
+from nova_act.cli.browser.services.step_tracking import write_steps_summary
+from nova_act.cli.browser.utils.log_capture import get_current_command_dir, get_log_dir
+from nova_act.cli.browser.utils.session import get_active_page
+from nova_act.cli.core.json_output import is_json_mode
+from nova_act.cli.core.output import get_cli_stdout
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement
+    from nova_act.cli.browser.types import CommandParams
+
+logger = logging.getLogger(__name__)
+
+
+def emit_observe(nova_act: NovaAct) -> None:
+    """Run observe and emit the layout to CLI output."""
+    layout = run_observe(nova_act)
+    out = get_cli_stdout()
+    if not layout:
+        if is_json_mode():
+            click.echo(_json.dumps({"observe": {"error": "observe failed"}}), file=out)
+        else:
+            click.echo("observe: failed", file=out)
+        return
+    if is_json_mode():
+        click.echo(_json.dumps({"observe": {"layout": layout}}), file=out)
+    else:
+        click.echo(f"observe.layout: {layout}", file=out)
+
+
+def _capture_auto_snapshot(
+    nova_act: NovaAct,
+    session_info: SessionInfo,
+    cmd_dir: "Path",
+    command_name: str,
+) -> dict[str, object]:
+    """Capture accessibility snapshot and write to cmd_dir/snapshot.yaml."""
+    from nova_act.cli.browser.services.intent_resolution import flatten_snapshot
+
+    active_page = get_active_page(nova_act, session_info)
+    tree = active_page.accessibility.snapshot()
+    elements = flatten_snapshot(tree)
+    snapshot_data = [{"ref": e.ref, "role": e.role, "name": e.name, "value": e.value} for e in elements if e.name]
+    snapshot_path = cmd_dir / "snapshot.yaml"
+    snapshot_path.write_text(yaml.dump(snapshot_data, default_flow_style=False, sort_keys=False))
+    return {
+        "snapshot_path": str(snapshot_path),
+        "snapshot_summary": {
+            "url": active_page.url,
+            "title": active_page.title(),
+            "interactive_elements": len(snapshot_data),
+        },
+    }
+
+
+def _capture_auto_screenshot(
+    nova_act: NovaAct,
+    session_info: SessionInfo,
+    cmd_dir: "Path",
+) -> dict[str, object]:
+    """Capture screenshot and write to cmd_dir/screenshot.png."""
+    screenshot_path = cmd_dir / "screenshot.png"
+    screenshot_bytes = get_active_page(nova_act, session_info).screenshot()
+    screenshot_path.write_bytes(screenshot_bytes)
+    return {"screenshot_path": str(screenshot_path)}
+
+
+def auto_orientation(
+    nova_act: NovaAct, session_info: SessionInfo, params: "CommandParams", command_name: str
+) -> dict[str, object]:
+    """Capture auto-snapshot and auto-screenshot after command execution.
+
+    Returns metadata dict with snapshot_path, screenshot_path, and snapshot_summary.
+    Files are written into the per-command subdirectory.
+    """
+    metadata: dict[str, object] = {}
+    cmd_dir = get_current_command_dir()
+    if cmd_dir is None:
+        cmd_dir = get_log_dir(params.session_id)
+    cmd_dir.mkdir(parents=True, exist_ok=True)
+
+    if not params.no_snapshot:
+        try:
+            metadata.update(_capture_auto_snapshot(nova_act, session_info, cmd_dir, command_name))
+        except Exception:
+            logger.debug("Auto-snapshot failed for command '%s'", command_name)
+
+    if not params.no_screenshot:
+        try:
+            metadata.update(_capture_auto_screenshot(nova_act, session_info, cmd_dir))
+        except Exception:
+            logger.debug("Auto-screenshot failed for command '%s'", command_name)
+
+    return metadata
+
+
+def emit_steps_summary(
+    nova_act: NovaAct,
+    params: "CommandParams",
+    command_name: str,
+    snapshots: list[list[SnapshotElement]],
+) -> dict[str, object] | None:
+    """Write steps summary from trajectory + monkey-patch snapshots. Returns metadata or None."""
+    try:
+        log_dir = get_log_dir(params.session_id)
+        trajectory_dir = log_dir
+        cmd_dir = get_current_command_dir()
+        if cmd_dir is None:
+            cmd_dir = log_dir
+        return write_steps_summary(trajectory_dir, command_name, snapshots, cmd_dir)
+    except Exception:
+        logger.debug("Steps summary failed for command '%s'", command_name)
+        return None

--- a/src/nova_act/cli/browser/utils/parsing.py
+++ b/src/nova_act/cli/browser/utils/parsing.py
@@ -1,0 +1,68 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JSON schema parsing utilities for browser CLI commands."""
+
+import json
+from collections.abc import Mapping
+
+from pydantic import JsonValue
+
+from nova_act.cli.core.output import exit_with_error
+from nova_act.util.jsonschema import BOOL_SCHEMA, STRING_SCHEMA
+
+
+def _resolve_schema_shortcut(schema_lower: str) -> dict[str, JsonValue] | None:
+    """Resolve enum shortcuts to schema constants."""
+    if schema_lower == "bool" or schema_lower == "boolean":
+        return dict(BOOL_SCHEMA)
+    elif schema_lower == "string":
+        return dict(STRING_SCHEMA)
+    return None
+
+
+def _parse_json_with_error_handling(schema: str) -> dict[str, JsonValue]:
+    """Parse JSON string with user-friendly error handling."""
+    try:
+        result: dict[str, JsonValue] = json.loads(schema)
+        return result
+    except json.JSONDecodeError as e:
+        exit_with_error(
+            "Invalid JSON schema",
+            str(e),
+            suggestions=[
+                "Ensure schema is valid JSON",
+                "Use enum shortcuts: --schema bool, --schema string",
+                'Example: --schema \'{"type": "object", "properties": {"title": {"type": "string"}}}\'',
+                "Check for proper escaping of quotes",
+            ],
+        )
+        return {}  # Unreachable, but satisfies type checker
+
+
+def parse_json_schema(schema: str | None) -> Mapping[str, JsonValue] | None:
+    """Parse JSON schema string with error handling.
+
+    Supports both enum shortcuts and full JSON schemas:
+    - Enum shortcuts: 'bool', 'string'
+    - Full JSON: '{"type": "object", "properties": {...}}'
+    """
+    if not schema or not schema.strip():
+        return None
+
+    schema_lower = schema.lower().strip()
+    shortcut_result = _resolve_schema_shortcut(schema_lower)
+    if shortcut_result is not None:
+        return shortcut_result
+
+    return _parse_json_with_error_handling(schema)

--- a/src/nova_act/cli/browser/utils/session.py
+++ b/src/nova_act/cli/browser/utils/session.py
@@ -1,0 +1,402 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session management utilities for browser CLI commands."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act import NovaAct
+from nova_act.cli.browser.services.session.manager import SessionManager
+from nova_act.cli.browser.services.session.models import (
+    BrowserOptions,
+    SessionInfo,
+)
+from nova_act.cli.browser.services.step_tracking import (
+    patch_nova_act_for_step_snapshots,
+)
+from nova_act.cli.browser.utils.auth import AuthConfig, resolve_auth_mode
+from nova_act.cli.browser.utils.browser_config_cli import determine_headless_mode
+from nova_act.cli.browser.utils.disk_usage import check_disk_usage
+from nova_act.cli.browser.utils.log_capture import (
+    capture_command_log,
+    capture_failure_screenshot,
+    get_current_command_dir,
+)
+from nova_act.cli.browser.utils.nova_args import (
+    filter_constructor_args,
+    filter_method_args,
+    parse_nova_args,
+)
+from nova_act.cli.core.config import get_browser_cli_dir
+from nova_act.cli.core.exceptions import SessionNotFoundError
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+    from nova_act.cli.browser.services.intent_resolution.snapshot import SnapshotElement
+    from nova_act.cli.browser.types import CommandParams
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PreparedSession:
+    """Result of preparing a session for command execution.
+
+    Attributes:
+        session_info: The active or newly created session.
+        method_args: Parsed nova method-level arguments.
+        manager: The SessionManager instance managing this session.
+    """
+
+    session_info: SessionInfo
+    method_args: dict[str, object] = field(default_factory=dict)
+    manager: SessionManager = field(default_factory=SessionManager)
+
+
+def get_or_create_session(
+    manager: SessionManager,
+    session_id: str,
+    starting_page: str | None,
+    browser_options: BrowserOptions,
+    max_sessions: int | None = None,
+) -> SessionInfo:
+    """Get existing session or create new one with given parameters."""
+    # Try to recover an existing session.
+    try:
+        session_info = manager.get_session(session_id, auth_config=browser_options.auth_config)
+    except SessionNotFoundError:
+        session_info = None
+
+    # Reuse if the session has a live NovaAct instance.
+    if session_info is not None and session_info.nova_act_instance:
+        return session_info
+
+    # Session is missing or stale — clean up and create a new one.
+    try:
+        manager.close_session(session_id, force=True)
+    except SessionNotFoundError:
+        pass
+    return manager.create_session(
+        session_id,
+        starting_page=starting_page or "about:blank",
+        browser_options=browser_options,
+        max_sessions=max_sessions,
+    )
+
+
+def build_browser_options_from_params(
+    params: "CommandParams",
+    *,
+    nova_args: dict[str, object] | None = None,
+    auth_config: AuthConfig | None = None,
+) -> BrowserOptions:
+    """Build BrowserOptions from a CommandParams object.
+
+    Args:
+        params: CLI parameters containing browser configuration.
+        nova_args: Pre-parsed nova args dict. If None, parses from params.nova_arg.
+        auth_config: Resolved authentication configuration.
+    """
+    effective_headless = determine_headless_mode(params.headless, params.headed)
+    resolved_nova_args = nova_args if nova_args is not None else parse_nova_args(params.nova_arg)
+    if params.ignore_https_errors and "ignore_https_errors" not in resolved_nova_args:
+        resolved_nova_args["ignore_https_errors"] = True
+
+    return BrowserOptions(
+        headless=effective_headless,
+        headed=params.headed,
+        executable_path=params.executable_path,
+        profile_path=params.profile_path,
+        ignore_https_errors=params.ignore_https_errors,
+        nova_args=resolved_nova_args,
+        launch_args=list(params.launch_arg),
+        auth_config=auth_config,
+        use_default_chrome=params.use_default_chrome,
+        user_data_dir=params.user_data_dir,
+        cdp_endpoint_url=params.cdp,
+    )
+
+
+def get_nova_act_instance(session_info: SessionInfo) -> NovaAct:
+    """Get NovaAct instance from session, raising error if unavailable."""
+    if not session_info.nova_act_instance:
+        raise RuntimeError("NovaAct instance not available")
+    return session_info.nova_act_instance
+
+
+def get_active_page(nova_act: NovaAct, session_info: SessionInfo) -> Page:
+    """Return the Playwright page for the active tab.
+
+    Uses session_info.active_tab_index to look up the correct page from
+    the browser context. Falls back to nova_act.page if the index is out
+    of bounds (e.g., tabs were closed between invocations).
+
+    Args:
+        nova_act: NovaAct instance with a live browser context.
+        session_info: Session info containing the persisted active_tab_index.
+
+    Returns:
+        Playwright Page object for the selected tab.
+    """
+    try:
+        pages = nova_act.page.context.pages
+        idx = session_info.active_tab_index
+        if 0 <= idx < len(pages):
+            return pages[idx]
+    except Exception:
+        pass
+    return nova_act.page
+
+
+def patch_active_tab(nova_act: NovaAct, session_info: SessionInfo) -> None:
+    """Monkeypatch SDK page resolution to respect CLI tab selection.
+
+    When active_tab_index != 0, patches the actuator's get_page() so that
+    index == -1 returns the selected tab instead of the last-created page.
+    This makes AI commands (act, ask, execute, navigate, explore, etc.)
+    operate on the tab chosen via tab-select.
+
+    Safe: each CLI invocation is a fresh process, so the patch is isolated.
+    """
+    idx = session_info.active_tab_index
+    if idx == 0:
+        return  # Default behavior — no patch needed
+
+    try:
+        pm = nova_act._actuator._playwright_manager  # type: ignore[attr-defined]
+    except AttributeError:
+        logger.debug("Cannot patch active tab: actuator has no _playwright_manager")
+        return
+
+    original_get_page = pm.get_page
+
+    def patched_get_page(index: int):  # type: ignore[no-untyped-def]
+        if index == -1:
+            try:
+                pages = pm.context.pages
+                if 0 <= idx < len(pages):
+                    return pages[idx]
+            except Exception:
+                pass
+        return original_get_page(index)
+
+    pm.get_page = patched_get_page
+
+
+def get_session_manager() -> SessionManager:
+    """Get SessionManager instance for managing browser sessions."""
+    return SessionManager()
+
+
+@contextmanager
+def locked_session(manager: SessionManager, session_info: SessionInfo, session_id: str) -> Iterator[NovaAct]:
+    """Context manager that acquires session lock and provides NovaAct instance.
+
+    Args:
+        manager: SessionManager instance that owns the session state
+        session_info: Session information object
+        session_id: Session identifier for lock acquisition
+
+    Yields:
+        NovaAct instance for the locked session
+
+    Raises:
+        SessionLockTimeout: If lock cannot be acquired
+        RuntimeError: If NovaAct instance is not available
+    """
+    with manager.with_session_lock(session_id):
+        nova_act = get_nova_act_instance(session_info)
+        yield nova_act
+        # nova_act.stop() is intentionally NOT called here. The CLI uses a
+        # stateless subprocess model where each command is a fresh process.
+        # On process exit the OS closes the CDP WebSocket and Chrome releases
+        # the DevTools session. Verified empirically: 30 rapid-fire iterations
+        # without stop() produced 0 failures and no target accumulation.
+        # Calling stop() would add teardown latency and hang risk with no
+        # measurable stability benefit.
+
+
+from nova_act.cli.browser.utils.orientation import (  # noqa: E402 — deferred import
+    auto_orientation,
+    emit_observe,
+    emit_steps_summary,
+)
+
+
+def _handle_post_command(
+    nova_act: NovaAct,
+    session_info: SessionInfo,
+    params: "CommandParams",
+    command_name: str,
+    cmd_start: datetime,
+    step_snapshots: list[list[SnapshotElement]],
+    log_args: dict[str, object] | None,
+) -> None:
+    """Handle post-yield logic: observe, orientation, steps summary, stdout emission, and session recording."""
+    if params.observe:
+        emit_observe(nova_act)
+
+    # Auto-orientation: snapshot + screenshot after every command
+    orientation = auto_orientation(nova_act, session_info, params, command_name)
+
+    # Steps summary: parse trajectory + merge monkey-patch snapshots
+    steps_meta = emit_steps_summary(nova_act, params, command_name, step_snapshots)
+    if steps_meta:
+        orientation.update(steps_meta)
+
+    # Auto-record command to session manifest
+    try:
+        from nova_act.cli.browser.services.session_recorder import get_recorder
+
+        duration_ms = (datetime.now() - cmd_start).total_seconds() * 1000
+        recorder = get_recorder(params.session_id)
+        recorder.record_step(
+            command_name=command_name,
+            args=log_args,
+            started_at=cmd_start,
+            duration_ms=duration_ms,
+            screenshots=(
+                {k: str(v) for k, v in orientation.items() if k in ("screenshot_path", "snapshot_path")}
+                if orientation
+                else None
+            ),
+            steps_file=str(steps_meta.get("steps_path")) if steps_meta and steps_meta.get("steps_path") else None,
+        )
+    except Exception:
+        logger.debug("Session recording failed for command '%s'", command_name)
+
+
+@contextmanager
+def command_session(
+    command_name: str,
+    manager: SessionManager,
+    session_info: SessionInfo,
+    params: "CommandParams",
+    log_args: dict[str, object] | None = None,
+) -> Iterator[NovaAct]:
+    """Unified context manager combining log capture, session locking, and auto-screenshot.
+
+    Replaces the duplicated nested pattern::
+
+        with capture_command_log(...) as _:
+            with locked_session(...) as nova_act:
+                ...
+
+    On unhandled exceptions, automatically captures a failure screenshot (unless
+    ``params.no_screenshot_on_failure`` is set) and attaches the path to the
+    exception as ``_failure_screenshot``.
+
+    Args:
+        command_name: CLI command name for log file (e.g. "ask", "screenshot")
+        manager: SessionManager instance that owns the session state
+        session_info: Session information object
+        params: Shared CLI parameters (provides session_id, quiet, verbose, no_screenshot_on_failure)
+        log_args: Optional command arguments to record in log metadata
+
+    Yields:
+        NovaAct instance for the locked session
+    """
+    with capture_command_log(
+        command_name,
+        session_id=params.session_id,
+        args=log_args,
+        quiet=params.quiet,
+        verbose=params.verbose,
+    ):
+        with locked_session(manager, session_info, params.session_id) as nova_act:
+            # Patch SDK page resolution to respect tab-select
+            patch_active_tab(nova_act, session_info)
+
+            # Capture before-screenshot for visual history
+            if not params.no_screenshot:
+                try:
+                    cmd_dir = get_current_command_dir()
+                    if cmd_dir is not None:
+                        cmd_dir.mkdir(parents=True, exist_ok=True)
+                        before_path = cmd_dir / "before.png"
+                        get_active_page(nova_act, session_info).screenshot(path=str(before_path))
+                except Exception:
+                    logger.debug("Before-screenshot failed for command '%s'", command_name)
+
+            # Monkey-patch for per-step a11y snapshots
+            step_snapshots: list[list[SnapshotElement]] = []
+            patch_nova_act_for_step_snapshots(nova_act, step_snapshots)
+
+            _cmd_start = datetime.now()
+            try:
+                yield nova_act
+            except Exception as exc:
+                if not params.no_screenshot_on_failure:
+                    screenshot_path = capture_failure_screenshot(nova_act, params.session_id, command_name)
+                    if screenshot_path:
+                        exc._failure_screenshot = screenshot_path  # type: ignore[attr-defined]
+                raise
+            else:
+                _handle_post_command(
+                    nova_act,
+                    session_info,
+                    params,
+                    command_name,
+                    _cmd_start,
+                    step_snapshots,
+                    log_args,
+                )
+
+
+def prepare_session(
+    params: "CommandParams",
+    starting_page: str | None,
+) -> PreparedSession:
+    """Parse nova args, prepare browser options, and get or create a session.
+
+    Args:
+        params: Shared CLI parameters packed by @pack_command_params.
+        starting_page: Starting URL for new sessions (command-specific).
+
+    Returns:
+        PreparedSession with session info, method args, and manager.
+    """
+    nova_args = parse_nova_args(params.nova_arg)
+    constructor_args = filter_constructor_args(nova_args)
+    method_args = filter_method_args(nova_args)
+
+    auth_config = resolve_auth_mode(params.auth_mode, params.profile, params.region, params.workflow_name)
+    browser_options = build_browser_options_from_params(
+        params,
+        nova_args=constructor_args,
+        auth_config=auth_config,
+    )
+
+    manager = get_session_manager()
+    session_info = get_or_create_session(manager, params.session_id, starting_page, browser_options)
+
+    _emit_disk_warning()
+
+    return PreparedSession(session_info=session_info, method_args=method_args, manager=manager)
+
+
+def _emit_disk_warning() -> None:
+    """Check disk usage and emit warning to stderr if over threshold."""
+    warning = check_disk_usage(get_browser_cli_dir())
+    if warning:
+        click.echo(warning, err=True)

--- a/src/nova_act/cli/browser/utils/timeout.py
+++ b/src/nova_act/cli/browser/utils/timeout.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Timeout context managers for browser CLI commands."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    from nova_act import NovaAct
+
+from nova_act.cli.browser.utils.browser_config_cli import convert_timeout_to_ms
+
+DEFAULT_TIMEOUT_MS = 30_000
+
+
+@contextmanager
+def temporary_timeout(nova_act: NovaAct, timeout: int | None) -> Iterator[None]:
+    """Temporarily set page timeout, restoring default afterward."""
+    if timeout is None:
+        yield
+        return
+    nova_act.page.set_default_timeout(convert_timeout_to_ms(timeout))
+    try:
+        yield
+    finally:
+        nova_act.page.set_default_timeout(DEFAULT_TIMEOUT_MS)
+
+
+@contextmanager
+def temporary_navigation_timeout(nova_act: NovaAct, timeout: int | None) -> Iterator[None]:
+    """Temporarily set navigation timeout, restoring default afterward."""
+    if timeout is None:
+        yield
+        return
+    nova_act.page.set_default_navigation_timeout(convert_timeout_to_ms(timeout))
+    try:
+        yield
+    finally:
+        nova_act.page.set_default_navigation_timeout(DEFAULT_TIMEOUT_MS)

--- a/src/nova_act/cli/browser/utils/validation_utils.py
+++ b/src/nova_act/cli/browser/utils/validation_utils.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation and error handling utilities for browser CLI commands."""
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from nova_act.cli.browser.services.session.manager import SessionManager
+
+from nova_act.cli.core.json_output import ErrorCode
+from nova_act.cli.core.output import exit_with_error
+
+# Protocols accepted across all URL validation functions
+VALID_URL_PREFIXES = ("http://", "https://", "about:", "app://")
+
+__all__ = [
+    "VALID_URL_PREFIXES",
+    "validate_url_format",
+    "warn_missing_protocol",
+    "require_argument",
+    "validate_prompt",
+    "validate_session_available",
+    "validate_starting_page",
+]
+
+
+def validate_url_format(url: str, param_name: str = "URL") -> None:
+    """Validate URL has proper protocol format."""
+    if not url.startswith(VALID_URL_PREFIXES):
+        exit_with_error(
+            f"Invalid {param_name} format: {url}",
+            f"{param_name} must include protocol (http:// or https://)",
+            suggestions=[f"Try: https://{url}", "Example: https://example.com"],
+            error_code=ErrorCode.VALIDATION_ERROR,
+        )
+
+
+def warn_missing_protocol(url: str) -> None:
+    """Warn if URL is missing a recognized protocol prefix."""
+    if not url.startswith(VALID_URL_PREFIXES):
+        prefix_list = ", ".join(VALID_URL_PREFIXES)
+        click.echo(
+            click.style(
+                f"⚠ Warning: URL '{url}' does not start with a recognized protocol ({prefix_list})",
+                fg="yellow",
+            )
+        )
+
+
+def require_argument(value: str | None, param_name: str, example: str) -> None:
+    """Validate that a required argument is provided."""
+    if not value:
+        exit_with_error(
+            f"Missing {param_name} argument",
+            f"{param_name} is required",
+            suggestions=[
+                f"Provide a {param_name}: {example}",
+                "Include protocol (http:// or https://)" if "URL" in param_name else f"Example: {example}",
+            ],
+            error_code=ErrorCode.VALIDATION_ERROR,
+        )
+
+
+def validate_prompt(prompt: str) -> None:
+    """Validate prompt is non-empty.
+
+    Args:
+        prompt: The prompt string to validate
+
+    Raises:
+        click.exceptions.Exit: If prompt is empty or whitespace-only
+    """
+    if not prompt.strip():
+        exit_with_error(
+            "Empty prompt",
+            "Prompt cannot be empty",
+            suggestions=[
+                "Provide a meaningful action: act browser execute 'Click the submit button'",
+                "Example: act browser execute 'Extract the page title'",
+            ],
+            error_code=ErrorCode.VALIDATION_ERROR,
+        )
+
+
+def validate_session_available(session_id: str, manager: "SessionManager") -> None:
+    """Validate that a session ID is available for creation.
+
+    Args:
+        session_id: ID to validate
+        manager: SessionManager instance
+
+    Raises:
+        click.exceptions.Exit: If session already exists
+    """
+    if manager.session_exists(session_id):
+        exit_with_error(
+            f"Session '{session_id}' already exists",
+            "Cannot create a session with an existing ID",
+            suggestions=[
+                "Use a different session ID: --session-id <unique-id>",
+                f"Close existing session: act browser session close {session_id}",
+                "List active sessions: act browser session list",
+            ],
+            error_code=ErrorCode.SESSION_EXISTS,
+        )
+
+
+def validate_starting_page(starting_page: str | None) -> None:
+    """Validate starting page URL format if provided.
+
+    Args:
+        starting_page: Optional starting page URL
+
+    Raises:
+        click.exceptions.Exit: If starting page format is invalid
+    """
+    if starting_page:
+        validate_url_format(starting_page, "Starting page")

--- a/src/nova_act/cli/cli.py
+++ b/src/nova_act/cli/cli.py
@@ -26,6 +26,7 @@ except ImportError:
 import os
 
 from nova_act.cli.__version__ import VERSION
+from nova_act.cli.browser import browser
 from nova_act.cli.core.styling import initialize_theme
 from nova_act.cli.core.theme import ThemeName, set_active_theme
 from nova_act.cli.group import StyledGroup
@@ -33,6 +34,7 @@ from nova_act.cli.workflow.commands.create import create
 from nova_act.cli.workflow.commands.delete import delete
 from nova_act.cli.workflow.commands.deploy import deploy
 from nova_act.cli.workflow.commands.list import list
+from nova_act.cli.workflow.commands.list_runs import list_runs
 from nova_act.cli.workflow.commands.run import run
 from nova_act.cli.workflow.commands.show import show
 from nova_act.cli.workflow.commands.update import update
@@ -54,6 +56,7 @@ workflow.add_command(show)
 workflow.add_command(deploy)
 workflow.add_command(run)
 workflow.add_command(list)
+workflow.add_command(list_runs)
 
 
 @click.group(cls=StyledGroup)
@@ -67,6 +70,7 @@ def main(no_color: bool) -> None:
 
 
 main.add_command(workflow)
+main.add_command(browser)
 
 if __name__ == "__main__":
     main()

--- a/src/nova_act/cli/core/cli_stdout.py
+++ b/src/nova_act/cli/core/cli_stdout.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI stdout management — shared by output.py and json_output.py to avoid circular imports."""
+
+import sys
+from contextvars import ContextVar
+from typing import TextIO
+
+# Original stdout — set by capture_command_log so CLI output bypasses the tee writer
+_original_stdout: ContextVar[TextIO | None] = ContextVar("_original_stdout", default=None)
+
+
+def get_cli_stdout() -> TextIO:
+    """Get the original stdout for CLI output (bypasses capture_command_log tee)."""
+    return _original_stdout.get() or sys.stdout
+
+
+def set_original_stdout(stream: TextIO | None) -> None:
+    """Set the original stdout (called by capture_command_log)."""
+    _original_stdout.set(stream)

--- a/src/nova_act/cli/core/clients/nova_act/client.py
+++ b/src/nova_act/cli/core/clients/nova_act/client.py
@@ -30,7 +30,10 @@ from nova_act.cli.core.clients.nova_act.types import (
     GetWorkflowDefinitionResponse,
     ListWorkflowDefinitionsRequest,
     ListWorkflowDefinitionsResponse,
+    ListWorkflowRunsRequest,
+    ListWorkflowRunsResponse,
     WorkflowDefinitionSummary,
+    WorkflowRunSummary,
 )
 from nova_act.cli.core.constants import DEFAULT_REGION
 
@@ -86,3 +89,29 @@ class NovaActClient:
 
         logger.info(f"Listed {len(all_summaries)} workflow definitions")
         return all_summaries
+
+    def list_workflow_runs(
+        self, workflow_name: str, *, max_results: int = 100, sort_order: str = "Descending"
+    ) -> list[WorkflowRunSummary]:
+        """List workflow runs for a given workflow definition, handling pagination."""
+        all_runs: list[WorkflowRunSummary] = []
+        next_token: str | None = None
+
+        while True:
+            request = ListWorkflowRunsRequest(
+                workflowDefinitionName=workflow_name,
+                maxResults=max_results,
+                nextToken=next_token,
+                sortOrder=sort_order,
+            )
+            params = request.model_dump(exclude_none=True)
+            response = self._client.list_workflow_runs(**params)
+            parsed = ListWorkflowRunsResponse.model_validate(response)
+            all_runs.extend(parsed.workflowRunSummaries)
+
+            next_token = parsed.nextToken
+            if not next_token:
+                break
+
+        logger.info(f"Listed {len(all_runs)} workflow runs for '{workflow_name}'")
+        return all_runs

--- a/src/nova_act/cli/core/clients/nova_act/types.py
+++ b/src/nova_act/cli/core/clients/nova_act/types.py
@@ -73,3 +73,24 @@ class WorkflowDefinitionSummary(BaseModel):
 class ListWorkflowDefinitionsResponse(BaseModel):
     workflowDefinitionSummaries: list[WorkflowDefinitionSummary]
     nextToken: str | None = None
+
+
+class ListWorkflowRunsRequest(BaseModel):
+    workflowDefinitionName: str
+    maxResults: int | None = None
+    nextToken: str | None = None
+    sortOrder: str | None = None
+
+
+class WorkflowRunSummary(BaseModel):
+    workflowRunArn: str
+    workflowRunId: str
+    status: str
+    startedAt: datetime
+    endedAt: datetime | None = None
+    traceLocation: str | None = None
+
+
+class ListWorkflowRunsResponse(BaseModel):
+    workflowRunSummaries: list[WorkflowRunSummary]
+    nextToken: str | None = None

--- a/src/nova_act/cli/core/config.py
+++ b/src/nova_act/cli/core/config.py
@@ -11,15 +11,114 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Configuration management for regional workflow support."""
+"""Configuration management for CLI paths and config I/O.
 
+Single source of truth for all CLI directory paths and config file operations.
+All CLI paths live under ~/.act_cli — browser CLI under ~/.act_cli/browser,
+workflow CLI under ~/.act_cli directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
+
+import yaml
 
 from nova_act.cli.core.constants import BUILDS_DIR_NAME, CONFIG_DIR_NAME
 
+logger = logging.getLogger(__name__)
+
+# Browser CLI subdirectory under ~/.act_cli
+BROWSER_CLI_SUBDIR = "browser"
+
+# Browser CLI config file name
+BROWSER_CLI_CONFIG_FILE = "config.yaml"
+
+
+@dataclass
+class BrowserCliConfig:
+    """Typed schema for browser CLI configuration (YAML-backed).
+
+    Attributes:
+        api_key: Nova Act API key for authentication.
+        aws_profile: Default AWS profile name for AWS auth.
+        aws_region: Default AWS region for AWS auth.
+        workflow_name: Default workflow definition name for AWS auth.
+    """
+
+    api_key: str | None = field(default=None)
+    aws_profile: str | None = field(default=None)
+    aws_region: str | None = field(default=None)
+    workflow_name: str | None = field(default=None)
+
+
+def get_browser_cli_dir() -> Path:
+    """Get browser CLI base directory (~/.act_cli/browser)."""
+    return get_cli_config_dir() / BROWSER_CLI_SUBDIR
+
+
+def get_browser_cli_config_file() -> Path:
+    """Get browser CLI config file path (~/.act_cli/browser/config.yaml)."""
+    return get_browser_cli_dir() / BROWSER_CLI_CONFIG_FILE
+
+
+def get_log_base_dir() -> Path:
+    """Get log base directory (~/.act_cli/browser/session_logs)."""
+    return get_browser_cli_dir() / "session_logs"
+
+
+def read_config() -> BrowserCliConfig:
+    """Read browser CLI YAML config file into typed schema.
+
+    Falls back to legacy key=value format for migration support.
+    """
+    config_file = get_browser_cli_config_file()
+    if not config_file.exists():
+        # Check legacy location for migration
+        return _read_legacy_config()
+
+    try:
+        data = yaml.safe_load(config_file.read_text()) or {}
+        return BrowserCliConfig(**{k: v for k, v in data.items() if k in BrowserCliConfig.__dataclass_fields__})
+    except Exception:
+        logger.debug("Failed to parse config %s, returning defaults", config_file, exc_info=True)
+        return BrowserCliConfig()
+
+
+def _read_legacy_config() -> BrowserCliConfig:
+    """Read legacy key=value config from ~/.nova-act-cli/config for migration."""
+    legacy_file = Path.home() / ".nova-act-cli" / "config"
+    if not legacy_file.exists():
+        return BrowserCliConfig()
+
+    config: dict[str, str] = {}
+    for line in legacy_file.read_text().splitlines():
+        line = line.strip()
+        if "=" in line and not line.startswith("#"):
+            key, _, value = line.partition("=")
+            config[key.strip()] = value.strip()
+
+    return BrowserCliConfig(api_key=config.get("api_key"))
+
+
+def write_config(config: BrowserCliConfig) -> None:
+    """Write browser CLI config to YAML file with restrictive permissions."""
+    config_dir = get_browser_cli_dir()
+    config_file = get_browser_cli_config_file()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(config_dir, stat.S_IRWXU)  # 0o700
+
+    data = {k: v for k, v in asdict(config).items() if v is not None}
+    config_file.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+    os.chmod(config_file, stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+
 
 def get_cli_config_dir() -> Path:
-    """Get CLI configuration directory path."""
+    """Get workflow CLI configuration directory path (~/.act_cli)."""
     return Path.home() / CONFIG_DIR_NAME
 
 
@@ -56,3 +155,8 @@ def get_builds_dir() -> Path:
 def get_workflow_build_dir(workflow_name: str) -> Path:
     """Get build directory path for specific workflow."""
     return get_builds_dir() / workflow_name
+
+
+def get_session_dir() -> Path:
+    """Get session directory path for browser session persistence."""
+    return get_browser_cli_dir() / "sessions"

--- a/src/nova_act/cli/core/constants.py
+++ b/src/nova_act/cli/core/constants.py
@@ -32,3 +32,6 @@ DEFAULT_ENTRY_POINT = "main.py"
 # Theme configuration
 DEFAULT_THEME = ThemeName.DEFAULT
 THEME_ENV_VAR = "ACT_CLI_THEME"
+
+# Date/time formatting
+DEFAULT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"

--- a/src/nova_act/cli/core/exceptions.py
+++ b/src/nova_act/cli/core/exceptions.py
@@ -70,3 +70,33 @@ class CodeBuildError(NovaActCLIError):
     """Raised when CodeBuild operations fail."""
 
     pass
+
+
+class SessionError(NovaActCLIError):
+    """Base exception for session-related errors."""
+
+    pass
+
+
+class SessionLockTimeout(SessionError):
+    """Raised when session lock cannot be acquired within timeout."""
+
+    pass
+
+
+class SessionNotFoundError(SessionError, KeyError):
+    """Raised when a session ID is not found."""
+
+    pass
+
+
+class SessionLimitReached(SessionError):
+    """Raised when the maximum number of active sessions is reached."""
+
+    pass
+
+
+class BrowserProcessDead(SessionError):
+    """Raised when the browser process for a session is no longer running."""
+
+    pass

--- a/src/nova_act/cli/core/json_output.py
+++ b/src/nova_act/cli/core/json_output.py
@@ -1,0 +1,130 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JSON output mode for Nova Act CLI agent integration."""
+
+import json
+from collections.abc import Mapping
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import Enum
+
+import click
+
+from nova_act.cli.core.cli_stdout import get_cli_stdout
+
+_json_mode: ContextVar[bool] = ContextVar("_json_mode", default=False)
+
+
+class ErrorCode(str, Enum):
+    """Error codes for structured JSON error responses."""
+
+    SESSION_NOT_FOUND = "SESSION_NOT_FOUND"
+    SESSION_BUSY = "SESSION_BUSY"
+    SESSION_EXISTS = "SESSION_EXISTS"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    BROWSER_ERROR = "BROWSER_ERROR"
+    TIMEOUT_ERROR = "TIMEOUT_ERROR"
+    NAVIGATION_ERROR = "NAVIGATION_ERROR"
+    FILE_ERROR = "FILE_ERROR"
+    INTERRUPTED = "INTERRUPTED"
+    SESSION_LIMIT_REACHED = "SESSION_LIMIT_REACHED"
+    AUTH_ERROR = "AUTH_ERROR"
+    ACT_TIMEOUT_ERROR = "ACT_TIMEOUT_ERROR"
+    ACT_MAX_STEPS_ERROR = "ACT_MAX_STEPS_ERROR"
+    ACT_GUARDRAILS_ERROR = "ACT_GUARDRAILS_ERROR"
+    ACT_RATE_LIMIT_ERROR = "ACT_RATE_LIMIT_ERROR"
+    CHROME_NOT_FOUND = "CHROME_NOT_FOUND"
+    ASSERTION_FAILED = "ASSERTION_FAILED"
+    UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
+
+
+@dataclass(frozen=True)
+class JsonResponse:
+    """Structured JSON response payload for CLI agent integration.
+
+    Attributes:
+        status: Response status — "success" or "error".
+        data: Response data payload.
+        code: Error code (only for error responses).
+        message: Error message (only for error responses).
+        retryable: Whether the error is retryable (only for error responses).
+        log: Path to command log file.
+    """
+
+    status: str
+    data: dict[str, object] = field(default_factory=dict)
+    code: str | None = None
+    message: str | None = None
+    retryable: bool = False
+    log: str | None = None
+    log_dir: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to dict, omitting None fields."""
+        result: dict[str, object] = {"status": self.status, "data": self.data}
+        if self.code is not None:
+            result["code"] = self.code
+        if self.message is not None:
+            result["message"] = self.message
+        if self.code is not None:
+            result["retryable"] = self.retryable
+        if self.log is not None:
+            result["log"] = self.log
+        if self.log_dir is not None:
+            result["log_dir"] = self.log_dir
+        return result
+
+
+def is_json_mode() -> bool:
+    """Check if JSON output mode is active."""
+    return _json_mode.get()
+
+
+def set_json_mode(enabled: bool) -> None:
+    """Set JSON output mode."""
+    _json_mode.set(enabled)
+
+
+def _emit(response: JsonResponse) -> None:
+    """Serialize and print a JsonResponse."""
+    click.echo(json.dumps(response.to_dict(), default=str), file=get_cli_stdout())
+
+
+def json_success(
+    data: Mapping[str, object] | None = None, log_path: str | None = None, log_dir: str | None = None
+) -> None:
+    """Print structured JSON success response."""
+    _emit(JsonResponse(status="success", data=dict(data) if data else {}, log=log_path, log_dir=log_dir))
+
+
+def json_error(
+    code: ErrorCode,
+    message: str,
+    retryable: bool = False,
+    log_path: str | None = None,
+    log_dir: str | None = None,
+    details: Mapping[str, object] | None = None,
+) -> None:
+    """Print structured JSON error response."""
+    _emit(
+        JsonResponse(
+            status="error",
+            code=code.value,
+            message=message,
+            retryable=retryable,
+            data=dict(details) if details else {},
+            log=log_path,
+            log_dir=log_dir,
+        )
+    )

--- a/src/nova_act/cli/core/locking.py
+++ b/src/nova_act/cli/core/locking.py
@@ -1,0 +1,157 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""File-based locking utilities for Nova Act CLI."""
+
+import os
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
+from nova_act.cli.core.exceptions import SessionLockTimeout
+
+# Default lock timeout in seconds
+DEFAULT_LOCK_TIMEOUT_SECONDS = 30.0
+
+
+class FileLockManager:
+    """Manages file-based locks for thread-safe operations.
+
+    Provides locking using file-based locks to prevent
+    concurrent modifications to the same resource.
+
+    Primary consumer: browser/services/session/locking.py (SessionLockManager).
+    """
+
+    def __init__(self, lock_dir: Path, default_timeout: float = DEFAULT_LOCK_TIMEOUT_SECONDS):
+        """Initialize the file lock manager.
+
+        Args:
+            lock_dir: Directory where lock files are stored
+            default_timeout: Default timeout for lock acquisition in seconds
+        """
+        self.lock_dir = lock_dir
+        self.default_timeout = default_timeout
+        self._locks: dict[str, FileLock] = {}
+
+    def _lock_file_path(self, resource_id: str) -> Path:
+        """Get path to lock file.
+
+        Args:
+            resource_id: Unique identifier for the resource
+
+        Returns:
+            Path to lock file
+        """
+        return self.lock_dir / f"{resource_id}.lock"
+
+    def get_lock_file_path(self, resource_id: str) -> Path:
+        """Get path to lock file for a resource.
+
+        Args:
+            resource_id: Unique identifier for the resource
+
+        Returns:
+            Path to lock file
+        """
+        return self._lock_file_path(resource_id)
+
+    def remove_lock(self, resource_id: str) -> None:
+        """Remove lock from memory and delete lock file from filesystem.
+
+        Args:
+            resource_id: Unique identifier for the resource to unlock
+        """
+        if resource_id in self._locks:
+            del self._locks[resource_id]
+
+        lock_path = self._lock_file_path(resource_id)
+        if lock_path.exists():
+            lock_path.unlink()
+
+    def _get_or_create_lock(self, resource_id: str) -> FileLock:
+        """Get existing lock or create new one for resource.
+
+        Args:
+            resource_id: Unique identifier for the resource
+
+        Returns:
+            FileLock for the resource
+        """
+        if resource_id not in self._locks:
+            lock_path = self._lock_file_path(resource_id)
+            self._locks[resource_id] = FileLock(str(lock_path))
+        return self._locks[resource_id]
+
+    def _is_locking_disabled(self) -> bool:
+        """Check if locking is disabled for testing.
+
+        Returns:
+            True if locking is disabled via environment variable
+        """
+        return os.environ.get("NOVA_ACT_DISABLE_SESSION_LOCK") == "1"
+
+    def _acquire_lock_with_timeout(self, lock: FileLock, resource_id: str, timeout: float) -> None:
+        """Acquire file lock with timeout handling.
+
+        Args:
+            lock: FileLock to acquire
+            resource_id: Resource identifier for error messages
+            timeout: Maximum time to wait for lock acquisition
+
+        Raises:
+            SessionLockTimeout: If lock cannot be acquired within timeout
+        """
+        try:
+            lock.acquire(timeout=timeout)
+        except FileLockTimeout:
+            raise SessionLockTimeout(f"Resource '{resource_id}' is busy. Another operation is in progress.")
+
+    @contextmanager
+    def with_lock(
+        self,
+        resource_id: str,
+        exists_check: Callable[[str], None],
+        timeout: float | None = None,
+    ) -> Generator[None, None, None]:
+        """Context manager for file-based locking.
+
+        Args:
+            resource_id: Unique identifier for the resource
+            exists_check: Callable that raises KeyError if resource doesn't exist
+            timeout: Maximum time to wait for lock acquisition in seconds
+
+        Yields:
+            None (lock is held during context)
+
+        Raises:
+            KeyError: If resource does not exist
+            SessionLockTimeout: If lock cannot be acquired within timeout
+        """
+        if self._is_locking_disabled():
+            yield
+            return
+
+        exists_check(resource_id)
+        lock = self._get_or_create_lock(resource_id)
+        effective_timeout = timeout if timeout is not None else self.default_timeout
+
+        self._acquire_lock_with_timeout(lock, resource_id, effective_timeout)
+
+        try:
+            yield
+        finally:
+            lock.release()

--- a/src/nova_act/cli/core/nova_args.py
+++ b/src/nova_act/cli/core/nova_args.py
@@ -1,0 +1,165 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for parsing and validating NovaAct constructor arguments from CLI."""
+
+import inspect
+from typing import get_type_hints
+
+from nova_act import NovaAct
+
+
+def parse_nova_arg(arg_string: str) -> tuple[str, str]:
+    """Parse a single --nova-arg key=value string.
+
+    Args:
+        arg_string: String in format "key=value"
+
+    Returns:
+        Tuple of (key, value) as strings
+
+    Raises:
+        ValueError: If format is invalid
+    """
+    if "=" not in arg_string:
+        raise ValueError(f"Invalid format: '{arg_string}'. Expected 'key=value'")
+
+    key, value = arg_string.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+
+    if not key:
+        raise ValueError(f"Empty key in: '{arg_string}'")
+
+    return key, value
+
+
+def coerce_type(value: str, target_type: type) -> object:
+    """Coerce string value to target type.
+
+    Args:
+        value: String value to coerce
+        target_type: Target type to coerce to
+
+    Returns:
+        Coerced value
+
+    Raises:
+        ValueError: If coercion fails
+    """
+    # Handle None/Optional types
+    if value.lower() == "none":
+        return None
+
+    # Handle bool specially (avoid bool("false") == True)
+    if target_type is bool:
+        if value.lower() in ("true", "1", "yes"):
+            return True
+        elif value.lower() in ("false", "0", "no"):
+            return False
+        else:
+            raise ValueError(f"Cannot convert '{value}' to bool")
+
+    # Handle int
+    if target_type is int:
+        return int(value)
+
+    # Handle float
+    if target_type is float:
+        return float(value)
+
+    # Handle str (no conversion needed)
+    if target_type is str:
+        return value
+
+    # For other types, attempt direct conversion
+    try:
+        return target_type(value)
+    except Exception as e:
+        raise ValueError(f"Cannot convert '{value}' to {target_type.__name__}: {e}")
+
+
+def validate_and_coerce_nova_args(args: dict[str, object]) -> dict[str, object]:
+    """Validate and coerce NovaAct constructor and method arguments.
+
+    Validates arguments against both NovaAct.__init__ and NovaAct.act/act_get methods.
+    Some parameters are only valid for method calls (max_steps, model_temperature, etc.)
+
+    Args:
+        args: Dictionary of argument names to string values
+
+    Returns:
+        Dictionary of validated and type-coerced arguments
+
+    Raises:
+        ValueError: If any argument is invalid
+    """
+    valid_params, type_hints = _gather_nova_act_params()
+
+    validated: dict[str, object] = {}
+    for key, value in args.items():
+        _validate_param_name(key, valid_params)
+        validated[key] = _coerce_param(key, str(value), type_hints)
+    return validated
+
+
+def _gather_nova_act_params() -> tuple[dict[str, inspect.Parameter], dict[str, type]]:
+    """Gather valid parameter names and type hints from NovaAct.__init__ and act()."""
+    sig = inspect.signature(NovaAct.__init__)
+    valid_params = {name: param for name, param in sig.parameters.items() if name != "self"}
+
+    try:
+        type_hints: dict[str, type] = get_type_hints(NovaAct.__init__)
+    except Exception:
+        type_hints = {}
+
+    try:
+        act_sig = inspect.signature(NovaAct.act)
+        act_params = {name: param for name, param in act_sig.parameters.items() if name != "self"}
+        act_type_hints = get_type_hints(NovaAct.act)
+        valid_params.update(act_params)
+        type_hints.update(act_type_hints)
+    except Exception:
+        pass
+
+    return valid_params, type_hints
+
+
+def _validate_param_name(key: str, valid_params: dict[str, inspect.Parameter]) -> None:
+    """Raise ValueError if key is not a valid NovaAct parameter."""
+    if key not in valid_params:
+        valid_names = ", ".join(sorted(valid_params.keys()))
+        raise ValueError(
+            f"Invalid argument '{key}' for NovaAct constructor or methods.\n" f"Valid arguments: {valid_names}"
+        )
+
+
+def _coerce_param(key: str, value: str, type_hints: dict[str, type]) -> object:
+    """Coerce a single parameter value to its target type based on type hints."""
+    param_type = type_hints.get(key)
+    if param_type is None:
+        return value
+
+    # Handle Union/Optional types (e.g., str | None)
+    if hasattr(param_type, "__args__"):
+        types = [t for t in param_type.__args__ if t is not type(None)]
+        if types:
+            param_type = types[0]
+
+    if isinstance(param_type, type):
+        try:
+            return coerce_type(value, param_type)
+        except ValueError as e:
+            raise ValueError(f"Invalid value for '{key}': {e}")
+
+    return value

--- a/src/nova_act/cli/core/output.py
+++ b/src/nova_act/cli/core/output.py
@@ -1,0 +1,294 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Output formatting utilities for Nova Act CLI."""
+
+__all__ = [
+    "EXIT_CODE_ERROR",
+    "echo_success",
+    "exit_with_error",
+    "format_error",
+    "format_info",
+    "format_success",
+    "get_cli_stdout",
+    "get_current_log_path",
+    "is_quiet_mode",
+    "is_verbose_mode",
+    "set_current_log_dir",
+    "set_current_log_path",
+    "set_original_stdout",
+    "set_quiet_mode",
+    "set_verbose_mode",
+]
+
+from collections.abc import Mapping
+from contextvars import ContextVar
+from typing import NoReturn, TextIO
+
+import click
+
+from nova_act.cli.core.cli_stdout import get_cli_stdout, set_original_stdout
+from nova_act.cli.core.json_output import ErrorCode, is_json_mode, json_error, json_success
+from nova_act.cli.core.styling import secondary, value
+from nova_act.cli.core.theme import get_active_theme
+
+# Constants
+EXIT_CODE_ERROR = 1
+
+# Verbose mode context var
+_verbose_mode: ContextVar[bool] = ContextVar("_verbose_mode", default=False)
+
+# Quiet mode context var
+_quiet_mode: ContextVar[bool] = ContextVar("_quiet_mode", default=False)
+
+# Log path context var — set by capture_command_log, read by output functions
+_current_log_path: ContextVar[str | None] = ContextVar("_current_log_path", default=None)
+
+# Log dir context var — set by capture_command_log, read by output functions
+_current_log_dir: ContextVar[str | None] = ContextVar("_current_log_dir", default=None)
+
+
+def is_verbose_mode() -> bool:
+    """Check if verbose output mode is active."""
+    return _verbose_mode.get()
+
+
+def set_verbose_mode(enabled: bool) -> None:
+    """Set verbose output mode."""
+    _verbose_mode.set(enabled)
+
+
+def is_quiet_mode() -> bool:
+    """Check if quiet output mode is active."""
+    return _quiet_mode.get()
+
+
+def set_quiet_mode(enabled: bool) -> None:
+    """Set quiet output mode."""
+    _quiet_mode.set(enabled)
+
+
+def get_current_log_path() -> str | None:
+    """Get the current command's log file path."""
+    return _current_log_path.get()
+
+
+def set_current_log_path(path: str | None) -> None:
+    """Set the current command's log file path."""
+    _current_log_path.set(path)
+
+
+def _get_log_dir() -> str | None:
+    """Get the current command's log directory path."""
+    return _current_log_dir.get()
+
+
+def set_current_log_dir(path: str | None) -> None:
+    """Set the current command's log directory path."""
+    _current_log_dir.set(path)
+
+
+def format_success(message: str, details: Mapping[str, object] | None = None) -> str:
+    """Format success message with optional details.
+
+    Args:
+        message: Success message
+        details: Optional key-value pairs to display
+
+    Returns:
+        Formatted success string
+    """
+    theme = get_active_theme()
+    lines = [theme.apply_success(f"✓ {message}")]
+    if details:
+        for key, val in details.items():
+            lines.append(f"  {secondary(f'{key}:')} {value(str(val))}")
+    return "\n".join(lines)
+
+
+def format_error(message: str, reason: str, suggestions: list[str] | None = None) -> str:
+    """Format error message with reason and suggestions.
+
+    Args:
+        message: Error message
+        reason: Reason for the error
+        suggestions: Optional list of suggestions
+
+    Returns:
+        Formatted error string
+    """
+    theme = get_active_theme()
+    lines = [
+        theme.apply_error(f"✗ {message}"),
+        f"  {secondary('Reason:')} {reason}",
+    ]
+    if suggestions:
+        lines.append("")
+        lines.append(f"  {secondary('Suggestions:')}")
+        for suggestion in suggestions:
+            lines.append(f"  • {suggestion}")
+    return "\n".join(lines)
+
+
+def format_info(message: str, details: Mapping[str, object] | None = None) -> str:
+    """Format info message with optional details.
+
+    Args:
+        message: Info message
+        details: Optional key-value pairs to display
+
+    Returns:
+        Formatted info string
+    """
+    theme = get_active_theme()
+    lines = [theme.apply_info(f"• {message}")]
+    if details:
+        for key, val in details.items():
+            lines.append(f"  {secondary(f'{key}:')} {value(str(val))}")
+    return "\n".join(lines)
+
+
+def echo_success(message: str, details: Mapping[str, object] | None = None) -> None:
+    """Format and echo success message with optional details.
+
+    Args:
+        message: Success message
+        details: Optional key-value pairs to display
+    """
+    log_path = get_current_log_path()
+    if is_quiet_mode():
+        _echo_success_quiet(log_path)
+    elif is_json_mode():
+        json_success(details, log_path=log_path, log_dir=_get_log_dir())
+    elif is_verbose_mode():
+        _echo_success_verbose(message, details, log_path)
+    else:
+        _echo_success_default(details, log_path)
+
+
+def _echo_success_quiet(log_path: str | None) -> None:
+    """Output success in quiet mode — log_dir only."""
+    log_dir = _get_log_dir()
+    if log_dir:
+        click.echo(f"log_dir: {log_dir}", file=get_cli_stdout())
+    elif log_path:
+        click.echo(f"log_dir: {log_path}", file=get_cli_stdout())
+
+
+def _echo_success_verbose(message: str, details: Mapping[str, object] | None, log_path: str | None) -> None:
+    """Output success in verbose mode — formatted with styling."""
+    out = get_cli_stdout()
+    click.echo(format_success(message, details), file=out)
+    log_dir = _get_log_dir()
+    if log_dir:
+        click.echo(f"  {secondary('log_dir:')} {value(log_dir)}", file=out)
+    elif log_path:
+        click.echo(f"  {secondary('log_dir:')} {value(log_path)}", file=out)
+
+
+def _echo_success_default(details: Mapping[str, object] | None, log_path: str | None) -> None:
+    """Output success in default mode — YAML-like compact."""
+    out = get_cli_stdout()
+    click.echo("status: success", file=out)
+    if details:
+        for key, val in details.items():
+            click.echo(f"{key}: {val}", file=out)
+    log_dir = _get_log_dir()
+    if log_dir:
+        click.echo(f"log_dir: {log_dir}", file=out)
+    elif log_path:
+        click.echo(f"log_dir: {log_path}", file=out)
+
+
+def exit_with_error(
+    title: str,
+    message: str,
+    suggestions: list[str],
+    error_code: ErrorCode = ErrorCode.UNEXPECTED_ERROR,
+    retryable: bool = False,
+    details: Mapping[str, object] | None = None,
+) -> NoReturn:
+    """Display formatted error and exit with error code."""
+    log_path = get_current_log_path()
+    out = get_cli_stdout()
+    if is_quiet_mode():
+        _exit_error_quiet(out, log_path)
+    elif is_json_mode():
+        _exit_error_json(error_code, message, retryable, log_path, details)
+    elif is_verbose_mode():
+        _exit_error_verbose(out, title, message, suggestions, details, log_path)
+    else:
+        _exit_error_default(out, error_code, message, retryable, suggestions, details, log_path)
+    raise click.exceptions.Exit(EXIT_CODE_ERROR)
+
+
+def _exit_error_quiet(out: TextIO, log_path: str | None) -> None:
+    """Output error in quiet mode — log_dir only."""
+    log_dir = _get_log_dir()
+    if log_dir:
+        click.echo(f"log_dir: {log_dir}", file=out)
+    elif log_path:
+        click.echo(f"log_dir: {log_path}", file=out)
+
+
+def _exit_error_json(
+    error_code: ErrorCode,
+    message: str,
+    retryable: bool,
+    log_path: str | None,
+    details: Mapping[str, object] | None,
+) -> None:
+    """Output error in JSON mode."""
+    json_error(error_code, message, retryable=retryable, log_path=log_path, log_dir=_get_log_dir(), details=details)
+
+
+def _exit_error_verbose(
+    out: TextIO,
+    title: str,
+    message: str,
+    suggestions: list[str],
+    details: Mapping[str, object] | None,
+    log_path: str | None,
+) -> None:
+    """Output error in verbose mode — formatted with styling."""
+    click.echo(format_error(title, message, suggestions=suggestions), file=out)
+    if details:
+        for key, val in details.items():
+            click.echo(f"  {secondary(f'{key}:')} {value(str(val))}", file=out)
+    if log_path:
+        click.echo(f"  {secondary('log_dir:')} {value(log_path)}", file=out)
+
+
+def _exit_error_default(
+    out: TextIO,
+    error_code: ErrorCode,
+    message: str,
+    retryable: bool,
+    suggestions: list[str],
+    details: Mapping[str, object] | None,
+    log_path: str | None,
+) -> None:
+    """Output error in default mode — YAML-like compact."""
+    click.echo("status: error", file=out)
+    click.echo(f"code: {error_code.value}", file=out)
+    click.echo(f"message: {message}", file=out)
+    click.echo(f"retryable: {str(retryable).lower()}", file=out)
+    if details:
+        for key, val in details.items():
+            click.echo(f"{key}: {val}", file=out)
+    if suggestions:
+        click.echo("suggestions:", file=out)
+        for s in suggestions:
+            click.echo(f"  - {s}", file=out)
+    if log_path:
+        click.echo(f"log_dir: {log_path}", file=out)

--- a/src/nova_act/cli/core/process.py
+++ b/src/nova_act/cli/core/process.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Process utilities for Nova Act CLI."""
+
+import psutil
+
+
+def is_process_running(pid: int | None) -> bool:
+    """Check if a process with given PID is still running.
+
+    Args:
+        pid: Process ID to check
+
+    Returns:
+        True if process is running, False otherwise
+    """
+    if pid is None:
+        return False
+
+    return psutil.pid_exists(pid)

--- a/src/nova_act/cli/workflow/commands/list_runs.py
+++ b/src/nova_act/cli/workflow/commands/list_runs.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Amazon Inc
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""List workflow runs command."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import click
+
+from nova_act.cli.core.styling import header, secondary, styled_error_exception, value
+from nova_act.cli.workflow.commands.error_handlers import handle_client_error, handle_credential_error
+
+if TYPE_CHECKING:
+    from nova_act.cli.core.clients.nova_act.types import WorkflowRunSummary
+
+
+def _format_duration(run: WorkflowRunSummary) -> str:
+    """Format duration from startedAt/endedAt."""
+    if not run.endedAt:
+        return "running"
+    delta = run.endedAt - run.startedAt
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    minutes, seconds = divmod(total_seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {seconds}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _display_runs_table(runs: list[WorkflowRunSummary], name: str) -> None:
+    """Display workflow runs in a table."""
+    click.echo(header(f"Workflow Runs for '{name}'"))
+    click.echo()
+
+    if not runs:
+        click.echo(secondary("  No runs found."))
+        return
+
+    # Column widths
+    id_width = max(len(r.workflowRunId[:8]) for r in runs)
+    status_width = max(len(r.status) for r in runs)
+
+    click.echo(f"  {'ID':<{id_width}}  {'STATUS':<{status_width}}  {'STARTED':<20}  DURATION")
+    click.echo(f"  {'─' * id_width}  {'─' * status_width}  {'─' * 20}  {'─' * 10}")
+
+    for run in runs:
+        run_id = run.workflowRunId[:8]
+        started = run.startedAt.strftime("%Y-%m-%d %H:%M:%S")
+        duration = _format_duration(run)
+        click.echo(
+            f"  {value(run_id):<{id_width}}  {secondary(run.status):<{status_width}}"
+            f"  {secondary(started):<20}  {secondary(duration)}"
+        )
+
+    click.echo()
+
+
+@click.command("list-runs")
+@click.option("--name", "-n", required=True, help="Workflow name")
+@click.option(
+    "--status",
+    type=click.Choice(["RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT"], case_sensitive=False),
+    help="Filter by status",
+)
+@click.option("--limit", default=20, type=int, help="Maximum runs to display (default: 20)")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+@click.option("--region", help="AWS region")
+def list_runs(
+    name: str,
+    status: str | None = None,
+    limit: int = 20,
+    as_json: bool = False,
+    region: str | None = None,
+) -> None:
+    """List runs for a workflow."""
+    try:
+        from boto3 import Session
+        from botocore.exceptions import ClientError, NoCredentialsError
+
+        from nova_act.cli.core.clients.nova_act.client import NovaActClient
+        from nova_act.cli.core.identity import auto_detect_account_id
+        from nova_act.cli.core.region import get_default_region
+
+        session = Session()
+        effective_region = region or get_default_region()
+        account_id = auto_detect_account_id(session=session, region=effective_region)
+
+        client = NovaActClient(boto_session=session, region_name=effective_region)
+        runs = client.list_workflow_runs(name)
+
+        # Filter by status if requested
+        if status:
+            runs = [r for r in runs if r.status == status.upper()]
+
+        # Apply limit
+        runs = runs[:limit]
+
+        if as_json:
+            output = [r.model_dump(mode="json") for r in runs]
+            click.echo(json.dumps(output, indent=2, default=str))
+        else:
+            _display_runs_table(runs, name)
+
+    except NoCredentialsError:
+        handle_credential_error()
+
+    except ClientError as e:
+        handle_client_error(
+            error=e, workflow_name=name, region=effective_region, account_id=account_id, context="listing workflow runs"
+        )
+
+    except Exception as e:
+        raise styled_error_exception(message=f"Unexpected error: {str(e)}") from e

--- a/src/nova_act/cli/workflow/commands/run.py
+++ b/src/nova_act/cli/workflow/commands/run.py
@@ -208,7 +208,6 @@ def _start_log_tailing(session: Session, client: AgentCoreClient, agent_arn: str
 
 def _create_log_callback() -> Callable[[LogEvent], None]:
     """Create callback function for log events."""
-    from nova_act.cli.workflow.utils.log_tailer import LogEvent
 
     def log_callback(log_event: LogEvent) -> None:
         timestamp = datetime.fromtimestamp(log_event.timestamp / 1000, tz=timezone.utc)


### PR DESCRIPTION
**Added**
- Add `act browser` CLI subcommand with browser automation commands for browsing (`execute`, `ask`, `goto`, `back`, `forward`, `refresh`, `click`, `type-text`, `fill-form`, `scroll-to`, `verify`, `wait-for`), extraction (`screenshot`, `snapshot`, `extract`, `query`, `get-content`, `evaluate`, `diff`, `pdf`, `perf`, `style`), tab management (`tab-new`, `tab-close`, `tab-list`, `tab-select`), and session management (`create`, `close`, `list`, `prune`, `export`, `trace-start`, `trace-stop`, `record-show`)
- Add `act browser doctor` and `act browser setup` commands for diagnostics and guided configuration
- Add `act browser qa-plan` command to generate Gherkin-based QA test plans from natural language
- Add `act workflow list-runs` command to list and filter workflow runs by status
- Add structured JSON output mode (`--json`), `--quiet`, `--verbose`, and `--observe` flags across browser CLI commands
- Add auto-orientation after browser commands with automatic accessibility snapshot and screenshot capture, controllable via `--no-snapshot` and `--no-screenshot`
- Add `--cdp` option to connect to existing browsers via Chrome DevTools Protocol
- Add `--use-default-chrome` option to launch the user's default Chrome with extensions
- Add `--nova-arg` repeatable option to pass `NovaAct` constructor and method parameters
- Add authentication auto-detection supporting API key (`NOVA_ACT_API_KEY`) and AWS credentials, configurable with `--auth-mode`, `--aws-profile`, `--region`, and `--workflow-name`
- Add persistent session management with file-based locking, metadata persistence, and automatic recovery across CLI invocations
- Add per-command log capture, per-step accessibility tracking, session recording manifest, disk usage monitoring, and failure screenshot auto-capture
- Add structured error handling with typed error codes and actionable suggestions
- Add `filelock`, `psutil`, `markdownify`, `rapidfuzz`, and `gherkin-official` as new CLI dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
