### PR TITLE
Fix Windows browser validation opening extra Chrome window

### DIFF
--- a/src/nova_act/cli/browser/services/session/chrome_launcher.py
+++ b/src/nova_act/cli/browser/services/session/chrome_launcher.py
@@ -168,6 +168,13 @@ class ChromeLauncher:
         if not os.access(executable_path, os.X_OK):
             raise RuntimeError(f"Browser executable is not executable: {executable_path}")
 
+        # On Windows, running `chrome.exe --version` when Chrome is already running
+        # opens a new browser window instead of printing version info. Check the
+        # executable path first to avoid this side effect.
+        path_lower = executable_path.lower()
+        if any(indicator in path_lower for indicator in ["chrome", "chromium", "edge"]):
+            return
+
         try:
             result = subprocess.run(
                 [executable_path, "--version"],
@@ -175,7 +182,7 @@ class ChromeLauncher:
                 text=True,
                 timeout=DefaultBrowserConfig.BROWSER_VERSION_CHECK_TIMEOUT_SECONDS,
             )
-            version_output = result.stdout.lower()
+            version_output = (result.stdout + result.stderr).lower()
             is_chromium = any(indicator in version_output for indicator in ["chrome", "chromium", "edge"])
             if not is_chromium:
                 raise RuntimeError(f"Browser is not Chromium-based: {executable_path}")


### PR DESCRIPTION
On Windows, running `chrome.exe --version` when Chrome is already running does not print version info to stdout. Instead it outputs "Opening in existing browser session." and opens a new browser window as a side effect.

This caused two issues:
1. The Chromium detection check failed with "Browser is not Chromium-based" because the expected version string was not in stdout.
2. An extra Chrome window was spawned before the actual session launch, resulting in two browser windows appearing.

Fix by checking the executable path name for known Chromium indicators (chrome, chromium, edge) before invoking --version. If the path already identifies the browser, skip the subprocess call entirely. The --version check is preserved as a fallback for unknown custom executables.

Also check stderr in addition to stdout for the --version output, as some platforms may write version info there.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
